### PR TITLE
ci(LH-70127): Do not run acceptance tests unless unit tests pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
   # Run acceptance tests in a matrix with Terraform CLI versions on merge to master
   acceptance-test:
     name: Terraform Provider Acceptance Tests
-    needs: build
+    needs: unit-test
     runs-on: ubuntu-latest
     if: ${{ (github.ref == 'refs/heads/main') || github.ref_type == 'tag' }}
     defaults:


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70127

### Description

There is no point running acceptance tests unles the unit tests pass, and we don't want to release if the unit tests pass. This makes the pipeline more serial.
