### PR TITLE
ci(LH-70319): Run acceptance tests on merge to main, not on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     name: Terraform Provider Acceptance Tests
     needs: unit-test
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') || github.ref_type == 'tag' }}
+    if: github.ref == 'refs/heads/main'
     defaults:
       run:
         working-directory: provider


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70319

### Description

Currently, we run the acceptance tests twice, once on a merge to main and then again when we create a tag to release the HEAD of main to the Terraform registry. This unnecessarily adds to the build time to release a new version of the terraform provider, as we essentially run the acceptance tests twice on each commit. With this commit, we will run the acceptance tests only on merge to main, and not when we tag a resource. When we tag a resource, we will proceed straight to releasing a new version of the provider to the Terraform registry.
