### PR TITLE
ci(LH-70586): Ensure release task is run when tag is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
   release:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
-    needs: [acceptance-test]
+    needs: [unit-test]
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70586

### Description

Yesterday, I merged a PR (https://github.com/CiscoDevNet/terraform-provider-cdo/pull/45) where I removed the requirement to run acceptance tests when pushing a tag (having acceptance tests run only on merge to main). However, I failed in that PR to remove the dependency between the `acceptance-tests` job and the `release` job. In this PR, I fix that and add a dependency from unit-test to release instead.

