### PR TITLE
feat(LH-70649): Add cdFMC data source to the Terraform provider

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/connector"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/asa/asaconfig"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudfmc"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudftd"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudftd/cloudftdonboarding"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/genericssh"
@@ -192,4 +193,8 @@ func (c *Client) DeleteFtdOnboarding(ctx context.Context, inp cloudftdonboarding
 
 func (c *Client) ReadTenantDetails(ctx context.Context) (*tenant.ReadTenantDetailsOutput, error) {
 	return tenant.ReadTenantDetails(ctx, c.client)
+}
+
+func (c *Client) ReadCloudFmc(ctx context.Context) (*device.ReadOutput, error) {
+	return cloudfmc.Read(ctx, c.client, cloudfmc.NewReadInput())
 }

--- a/client/device/read_by_uid.go
+++ b/client/device/read_by_uid.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/devicetype"
@@ -20,6 +21,7 @@ type ReadOutput struct {
 	ConnectorUid    string          `json:"larUid"`
 	ConnectorType   string          `json:"larType"`
 	SocketAddress   string          `json:"ipv4"`
+	SoftwareVersion string          `json:"softwareVersion"`
 	Port            string          `json:"port"`
 	Host            string          `json:"host"`
 

--- a/provider/examples/data-sources/cdfmc/example.tf
+++ b/provider/examples/data-sources/cdfmc/example.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    cdo = {
+      source = "hashicorp.com/CiscoDevnet/cdo"
+    }
+  }
+}
+
+provider "cdo" {
+  base_url  = "<https://www.defenseorchestrator.com|https://www.defenseorchestrator.eu|https://apj.cdo.cisco.com>"
+  api_token = "<replace-with-api-token-generated-from-cdo>"
+}
+
+data "cdo_cdfmc" "current" {
+}
+
+output "cdfmc_hostname" {
+    value = data.cdo_cdfmc.current.hostname
+}
+
+output "cdfmc_software_version" {
+    value = data.cdo_cdfmc.current.software_version
+}
+
+output "cdfmc_uid" {
+    value = data.cdo_cdfmc.current.id
+}

--- a/provider/internal/cdfmc/data_source.go
+++ b/provider/internal/cdfmc/data_source.go
@@ -1,0 +1,91 @@
+package cdfmc
+
+import (
+	"context"
+	"fmt"
+
+	cdoClient "github.com/CiscoDevnet/terraform-provider-cdo/go-client"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type DataSourceModel struct {
+	Uid             types.String `tfsdk:"id"`
+	Hostname        types.String `tfsdk:"hostname"`
+	SoftwareVersion types.String `tfsdk:"software_version"`
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{}
+}
+
+type DataSource struct {
+	client *cdoClient.Client
+}
+
+func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cdfmc"
+}
+
+func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Use this data source to get information on the cloud-delivered FMC in your tenant.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Universally unique identifier for the cdFMC.",
+				Computed:            true,
+			},
+			"hostname": schema.StringAttribute{
+				MarkdownDescription: "Name of the tenant.",
+				Computed:            true,
+			},
+			"software_version": schema.StringAttribute{
+				MarkdownDescription: "Software version of the cdFMC.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cdoClient.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *cdoClient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+
+	var planData DataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	cloudFmc, err := d.client.ReadCloudFmc(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read cdFMC", err.Error())
+		return
+	}
+	planData.Uid = types.StringValue(cloudFmc.Uid)
+	planData.Hostname = types.StringValue(cloudFmc.Host)
+	planData.SoftwareVersion = types.StringValue(cloudFmc.SoftwareVersion)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
+}

--- a/provider/internal/cdfmc/data_source_test.go
+++ b/provider/internal/cdfmc/data_source_test.go
@@ -1,0 +1,41 @@
+package cdfmc_test
+
+import (
+	"testing"
+
+	"github.com/CiscoDevnet/terraform-provider-cdo/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+var testCdFmc = struct {
+	Hostname        string
+	Uid             string
+	SoftwareVersion string
+}{
+	Hostname:        "terraform-provider-cdo.app.staging.cdo.cisco.com",
+	Uid:             "ac12b246-ed93-4a09-bc8a-5c4708854a2f",
+	SoftwareVersion: "7.3.1-build 6035",
+}
+
+const testTenantTemplate = `
+data "cdo_cdfmc" "test" {}`
+
+var testTenantConfig = acctest.MustParseTemplate(testTenantTemplate, testCdFmc)
+
+func TestAccCdFmcDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 acctest.PreCheckFunc(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: acctest.ProviderConfig() + testTenantConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "hostname", testCdFmc.Hostname),
+					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "id", testCdFmc.Uid),
+					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "software_version", testCdFmc.SoftwareVersion),
+				),
+			},
+		},
+	})
+}

--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -6,8 +6,10 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/CiscoDevnet/terraform-provider-cdo/internal/device/ftd/ftdonboarding"
 	"os"
+
+	"github.com/CiscoDevnet/terraform-provider-cdo/internal/cdfmc"
+	"github.com/CiscoDevnet/terraform-provider-cdo/internal/device/ftd/ftdonboarding"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/device/ftd"
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/tenant"
@@ -168,6 +170,7 @@ func (p *CdoProvider) DataSources(ctx context.Context) []func() datasource.DataS
 		ios.NewIosDataSource,
 		user.NewDataSource,
 		tenant.NewDataSource,
+		cdfmc.NewDataSource,
 	}
 }
 


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70649

### Description
Add a cdFMC data source to the Terraform provider in order to get info from the FMC (hostname and software version to start with).

