### PR TITLE
fix(LH-70649): Add the cdFMC domain UUID to list of data returned by the cdfmc data source

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -195,6 +195,10 @@ func (c *Client) ReadTenantDetails(ctx context.Context) (*tenant.ReadTenantDetai
 	return tenant.ReadTenantDetails(ctx, c.client)
 }
 
-func (c *Client) ReadCloudFmc(ctx context.Context) (*device.ReadOutput, error) {
+func (c *Client) ReadCloudFmcDevice(ctx context.Context) (*device.ReadOutput, error) {
 	return cloudfmc.Read(ctx, c.client, cloudfmc.NewReadInput())
+}
+
+func (c *Client) ReadCloudFmcSpecificDevice(ctx context.Context, inp cloudfmc.ReadSpecificInput) (*cloudfmc.ReadSpecificOutput, error) {
+	return cloudfmc.ReadSpecific(ctx, c.client, inp)
 }

--- a/provider/examples/data-sources/cdfmc/example.tf
+++ b/provider/examples/data-sources/cdfmc/example.tf
@@ -25,3 +25,7 @@ output "cdfmc_software_version" {
 output "cdfmc_uid" {
     value = data.cdo_cdfmc.current.id
 }
+
+output "cdfmc_domain_uuid" {
+    value = data.cdo_cdfmc.current.domain_uuid
+}

--- a/provider/internal/cdfmc/data_source_test.go
+++ b/provider/internal/cdfmc/data_source_test.go
@@ -11,16 +11,18 @@ var testCdFmc = struct {
 	Hostname        string
 	Uid             string
 	SoftwareVersion string
+	DomainUuid      string
 }{
 	Hostname:        "terraform-provider-cdo.app.staging.cdo.cisco.com",
 	Uid:             "ac12b246-ed93-4a09-bc8a-5c4708854a2f",
 	SoftwareVersion: "7.3.1-build 6035",
+	DomainUuid:      "e276abec-e0f2-11e3-8169-6d9ed49b625f",
 }
 
-const testTenantTemplate = `
+const testCdFmcTemplate = `
 data "cdo_cdfmc" "test" {}`
 
-var testTenantConfig = acctest.MustParseTemplate(testTenantTemplate, testCdFmc)
+var testCdfmcConfig = acctest.MustParseTemplate(testCdFmcTemplate, testCdFmc)
 
 func TestAccCdFmcDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -29,11 +31,12 @@ func TestAccCdFmcDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: acctest.ProviderConfig() + testTenantConfig,
+				Config: acctest.ProviderConfig() + testCdfmcConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "hostname", testCdFmc.Hostname),
 					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "id", testCdFmc.Uid),
 					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "software_version", testCdFmc.SoftwareVersion),
+					resource.TestCheckResourceAttr("data.cdo_cdfmc.test", "domain_uuid", testCdFmc.DomainUuid),
 				),
 			},
 		},


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70649

### Description

Also return the domain UUID when the cdFMC datasource is fetched

