### PR TITLE
feat(LH-69564): Supports ASA Onboarding Using New Model

### DIFF
--- a/client/device/asa/asafixture_test.go
+++ b/client/device/asa/asafixture_test.go
@@ -57,7 +57,7 @@ func configureDeviceCreateToRespondSuccessfullyWithNewModel(t *testing.T, create
 			if err != nil {
 				return nil, err
 			}
-			expectedMetadata := &asa.Metadata{IsNewPolicyObjectModel: true}
+			expectedMetadata := &asa.Metadata{IsNewPolicyObjectModel: "true"}
 			expectedBytes, err := json.Marshal(expectedMetadata)
 			if err != nil {
 				return nil, err

--- a/client/device/asa/create.go
+++ b/client/device/asa/create.go
@@ -39,7 +39,7 @@ type CreateOutput struct {
 }
 
 type Metadata struct {
-	IsNewPolicyObjectModel bool `json:"isNewPolicyObjectModel"`
+	IsNewPolicyObjectModel string `json:"isNewPolicyObjectModel"` // yes it is a string, but it should be either "true" or "false" :/
 }
 
 type CreateError struct {
@@ -79,7 +79,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	// 1.2 set metadata according to whether we want to use new asa model
 	var metadata *Metadata = nil
 	if userInfo.HasFeatureFlagEnabled(featureflag.AsaConfigurationObjectMigration) {
-		metadata = &Metadata{IsNewPolicyObjectModel: true}
+		metadata = &Metadata{IsNewPolicyObjectModel: "true"}
 	}
 	// 1.3 create the device
 	deviceCreateOutp, err := device.Create(ctx, client, *device.NewCreateRequestInput(

--- a/client/device/asa/create.go
+++ b/client/device/asa/create.go
@@ -10,6 +10,8 @@ import (
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/devicetype"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/featureflag"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/user"
 	"strings"
 )
 
@@ -34,6 +36,10 @@ type CreateOutput struct {
 	SocketAddress string          `json:"ipv4"`
 	ConnectorType string          `json:"larType"`
 	ConnectorUid  string          `json:"larUid"`
+}
+
+type Metadata struct {
+	IsNewPolicyObjectModel bool `json:"isNewPolicyObjectModel"`
 }
 
 type CreateError struct {
@@ -61,8 +67,23 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 
 	client.Logger.Println("creating asa device")
 
+	// 1. create a general CDO device with device type ASA
+	// 1.1 check if we should use the new asa model
+	userInfo, err := user.GetTokenInfo(ctx, client, user.NewGetTokenInfoInput())
+	if err != nil {
+		return nil, &CreateError{
+			CreatedResourceId: nil,
+			Err:               err,
+		}
+	}
+	// 1.2 set metadata according to whether we want to use new asa model
+	var metadata *Metadata = nil
+	if userInfo.HasFeatureFlagEnabled(featureflag.AsaConfigurationObjectMigration) {
+		metadata = &Metadata{IsNewPolicyObjectModel: true}
+	}
+	// 1.3 create the device
 	deviceCreateOutp, err := device.Create(ctx, client, *device.NewCreateRequestInput(
-		createInp.Name, "ASA", createInp.ConnectorUid, createInp.ConnectorType, createInp.SocketAddress, false, createInp.IgnoreCertificate,
+		createInp.Name, "ASA", createInp.ConnectorUid, createInp.ConnectorType, createInp.SocketAddress, false, createInp.IgnoreCertificate, metadata,
 	))
 	var createdResourceId *string = nil
 	if deviceCreateOutp != nil {
@@ -75,6 +96,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 		}
 	}
 
+	// 2. wait for creation to be done, by waiting until asa specific device state is done
 	client.Logger.Println("reading specific device uid")
 
 	asaReadSpecOutp, err := device.ReadSpecific(ctx, client, *device.NewReadSpecificInput(
@@ -118,7 +140,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 		}
 	}
 
-	// encrypt credentials on prem connector
+	// 3. encrypt credentials for on prem connector (sdc)
 	var publicKey *model.PublicKey
 	if strings.EqualFold(deviceCreateOutp.ConnectorType, "SDC") {
 

--- a/client/device/create.go
+++ b/client/device/create.go
@@ -8,19 +8,24 @@ import (
 )
 
 type CreateInput struct {
-	Name          string `json:"name"`
-	DeviceType    string `json:"deviceType"`
-	ConnectorUid  string `json:"larUid,omitempty"`
-	ConnectorType string `json:"larType"`
-	SocketAddress string `json:"ipv4"`
-	Model         bool   `json:"model"`
-
-	IgnoreCertificate bool `json:"ignoreCertificate"`
+	Name              string       `json:"name"`
+	DeviceType        string       `json:"deviceType"`
+	ConnectorUid      string       `json:"larUid,omitempty"`
+	ConnectorType     string       `json:"larType"`
+	SocketAddress     string       `json:"ipv4"`
+	Model             bool         `json:"model"`
+	IgnoreCertificate bool         `json:"ignoreCertificate"`
+	Metadata          *interface{} `json:"metadata,omitempty"`
 }
 
 type CreateOutput = ReadOutput
 
-func NewCreateRequestInput(name, deviceType, connectorUid, connectorType, socketAddress string, model bool, ignoreCertificate bool) *CreateInput {
+func NewCreateRequestInput(name, deviceType, connectorUid, connectorType, socketAddress string, model bool, ignoreCertificate bool, metadata interface{}) *CreateInput {
+	var metadataPtr *interface{} = nil
+	if metadata != nil {
+		metadataPtr = &metadata
+	}
+
 	return &CreateInput{
 		Name:              name,
 		DeviceType:        deviceType,
@@ -29,6 +34,7 @@ func NewCreateRequestInput(name, deviceType, connectorUid, connectorType, socket
 		SocketAddress:     socketAddress,
 		Model:             model,
 		IgnoreCertificate: ignoreCertificate,
+		Metadata:          metadataPtr,
 	}
 }
 

--- a/client/device/create.go
+++ b/client/device/create.go
@@ -21,6 +21,7 @@ type CreateInput struct {
 type CreateOutput = ReadOutput
 
 func NewCreateRequestInput(name, deviceType, connectorUid, connectorType, socketAddress string, model bool, ignoreCertificate bool, metadata interface{}) *CreateInput {
+	// convert interface{} to a pointer
 	var metadataPtr *interface{} = nil
 	if metadata != nil {
 		metadataPtr = &metadata

--- a/client/device/genericssh/create.go
+++ b/client/device/genericssh/create.go
@@ -28,7 +28,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 
 	client.Logger.Println("creating generic ssh")
 
-	deviceInput := device.NewCreateRequestInput(createInp.Name, "GENERIC_SSH", createInp.ConnectorUid, createInp.ConnectorType, createInp.SocketAddress, false, false)
+	deviceInput := device.NewCreateRequestInput(createInp.Name, "GENERIC_SSH", createInp.ConnectorUid, createInp.ConnectorType, createInp.SocketAddress, false, false, nil)
 	outp, err := device.Create(ctx, client, *deviceInput)
 	if err != nil {
 		return nil, err

--- a/client/device/ios/create.go
+++ b/client/device/ios/create.go
@@ -64,7 +64,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	client.Logger.Println("creating ios device")
 
 	deviceCreateOutp, err := device.Create(ctx, client, *device.NewCreateRequestInput(
-		createInp.Name, "IOS", createInp.ConnectorUid, createInp.ConnectorType, createInp.SocketAddress, false, createInp.IgnoreCertificate,
+		createInp.Name, "IOS", createInp.ConnectorUid, createInp.ConnectorType, createInp.SocketAddress, false, createInp.IgnoreCertificate, nil,
 	))
 	var createdResourceId *string = nil
 	if deviceCreateOutp != nil {

--- a/client/model/featureflag/featureflag.go
+++ b/client/model/featureflag/featureflag.go
@@ -1,0 +1,13 @@
+package featureflag
+
+import "strings"
+
+type Type string
+
+const (
+	AsaConfigurationObjectMigration Type = "asa_configuration_object_migration"
+)
+
+func (t Type) String() string {
+	return strings.ToLower(string(t))
+}

--- a/client/model/user/auth/info.go
+++ b/client/model/user/auth/info.go
@@ -48,7 +48,8 @@ func (info *Info) getFeatureMap() map[string]bool {
 		// feature flag received is not a json
 		panic(fmt.Sprintf("feature flag received from authentication service is not in valid format: %s", info.UserAuthentication.Details.TenantDbFeatures))
 	}
-
+	// convert feature flag keys to lowercase
+	// TODO: make use of lh-feature
 	normalizedFeatureMap := map[string]bool{}
 	for k, v := range featureMap {
 		normalizedFeatureMap[strings.ToLower(k)] = v

--- a/client/model/user/auth/info.go
+++ b/client/model/user/auth/info.go
@@ -1,6 +1,12 @@
 package auth
 
-import "github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/user/auth/role"
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/featureflag"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/user/auth/role"
+	"strings"
+)
 
 type Info struct {
 	UserAuthentication Authentication `json:"userAuthentication"`
@@ -27,4 +33,26 @@ type Details struct {
 	TenantUserRoles        string `json:"TenantUserRoles"`
 	TenantDatabaseName     string `json:"TenantDatabaseName"`
 	TenantPayType          string `json:"TenantPayType"`
+}
+
+func (info *Info) HasFeatureFlagEnabled(featureFlag featureflag.Type) bool {
+	featureMap := info.getFeatureMap()
+	enabled, ok := featureMap[featureFlag.String()]
+	return ok && enabled
+}
+
+func (info *Info) getFeatureMap() map[string]bool {
+	featureMap := map[string]bool{}
+	err := json.Unmarshal([]byte(info.UserAuthentication.Details.TenantDbFeatures), &featureMap)
+	if err != nil {
+		// feature flag received is not a json
+		panic(fmt.Sprintf("feature flag received from authentication service is not in valid format: %s", info.UserAuthentication.Details.TenantDbFeatures))
+	}
+
+	normalizedFeatureMap := map[string]bool{}
+	for k, v := range featureMap {
+		normalizedFeatureMap[strings.ToLower(k)] = v
+	}
+
+	return normalizedFeatureMap
 }

--- a/provider/examples/resources/asa/example.tf
+++ b/provider/examples/resources/asa/example.tf
@@ -7,15 +7,15 @@ terraform {
 }
 
 provider "cdo" {
-  base_url  = "https://ci.dev.lockhart.io"
-  api_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOiIwIiwic2NvcGUiOlsidHJ1c3QiLCJyZWFkIiwiMjA5MDc5M2UtNDQ1My00ZjI3LTg2YTYtZDY0YTAxMDQ4N2JjIiwid3JpdGUiXSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdLCJhbXIiOiJwd2QiLCJpc3MiOiJpdGQiLCJjbHVzdGVySWQiOiIxIiwiaWQiOiJmY2NlYTEzMC1jNDQ1LTQ1MzEtOTc1NS1jYmE5NWRlNGYwMTIiLCJzdWJqZWN0VHlwZSI6InVzZXIiLCJqdGkiOiI2MzlhNDgyNy1iYWQyLTQ2ZGUtYTY4ZC0wYTg1OTk1NDdmMGEiLCJwYXJlbnRJZCI6IjIwOTA3OTNlLTQ0NTMtNGYyNy04NmE2LWQ2NGEwMTA0ODdiYyIsImNsaWVudF9pZCI6ImFwaS1jbGllbnQifQ.3gyCSmx6-26dmcTZHFWIVYIDOhDP9cjJhg4wfPqCC-3BlZq6JWdMSNqOP_Q1SXz7GWrqvE4LRqZwj9i0XFWTDWuKvolJY2UcV3k5IVwmDjARn-97pujjjqERCMcm-x5hfJh9SegpVMUYYLqgQE16a-TVGAgzb2qus94qeot7Udga4bdVzwcdZWbxPFGhl8EK4Y9Qx34jHID4QyVW7u4PR2r701c5xh6sBUc4Jy37DU16exeTWOmkxLZdmhwdJv5t2Wm_Sy5BIGhNHoQwPZC_F0-T5i6ockML1iu_7rxpjcY-HxVger91Hliqyzd9gcDr7akUCdvNC0MerBKwZDgJCQ"
+  base_url  = "<https://www.defenseorchestrator.com|https://www.defenseorchestrator.eu|https://apj.cdo.cisco.com>"
+  api_token = "<replace-with-api-token-generated-from-cdo>"
 }
 
 resource "cdo_asa_device" "my_asa" {
-  name               = "wl-asa"
-  connector_type     = "CDG"
-  socket_address     = "52.53.230.145:443"
-  username           = "admin"
-  password           = ""
-  ignore_certificate = true
+  name               = "<replace-with-name-of-asa>"
+  connector_type     = "<CDG|SDC>"
+  socket_address     = "<host:port>"
+  username           = "<replace-with-username>"
+  password           = "<replace-with-password>"
+  ignore_certificate = "<replace-with-boolean-without-quotes-true-or-false>"
 }

--- a/provider/examples/resources/asa/example.tf
+++ b/provider/examples/resources/asa/example.tf
@@ -7,15 +7,15 @@ terraform {
 }
 
 provider "cdo" {
-  base_url  = "<https://www.defenseorchestrator.com|https://www.defenseorchestrator.eu|https://apj.cdo.cisco.com>"
-  api_token = "<replace-with-api-token-generated-from-cdo>"
+  base_url  = "https://ci.dev.lockhart.io"
+  api_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXIiOiIwIiwic2NvcGUiOlsidHJ1c3QiLCJyZWFkIiwiMjA5MDc5M2UtNDQ1My00ZjI3LTg2YTYtZDY0YTAxMDQ4N2JjIiwid3JpdGUiXSwicm9sZXMiOlsiUk9MRV9BRE1JTiJdLCJhbXIiOiJwd2QiLCJpc3MiOiJpdGQiLCJjbHVzdGVySWQiOiIxIiwiaWQiOiJmY2NlYTEzMC1jNDQ1LTQ1MzEtOTc1NS1jYmE5NWRlNGYwMTIiLCJzdWJqZWN0VHlwZSI6InVzZXIiLCJqdGkiOiI2MzlhNDgyNy1iYWQyLTQ2ZGUtYTY4ZC0wYTg1OTk1NDdmMGEiLCJwYXJlbnRJZCI6IjIwOTA3OTNlLTQ0NTMtNGYyNy04NmE2LWQ2NGEwMTA0ODdiYyIsImNsaWVudF9pZCI6ImFwaS1jbGllbnQifQ.3gyCSmx6-26dmcTZHFWIVYIDOhDP9cjJhg4wfPqCC-3BlZq6JWdMSNqOP_Q1SXz7GWrqvE4LRqZwj9i0XFWTDWuKvolJY2UcV3k5IVwmDjARn-97pujjjqERCMcm-x5hfJh9SegpVMUYYLqgQE16a-TVGAgzb2qus94qeot7Udga4bdVzwcdZWbxPFGhl8EK4Y9Qx34jHID4QyVW7u4PR2r701c5xh6sBUc4Jy37DU16exeTWOmkxLZdmhwdJv5t2Wm_Sy5BIGhNHoQwPZC_F0-T5i6ockML1iu_7rxpjcY-HxVger91Hliqyzd9gcDr7akUCdvNC0MerBKwZDgJCQ"
 }
 
 resource "cdo_asa_device" "my_asa" {
-  name               = "<replace-with-name-of-asa>"
-  connector_type     = "<CDG|SDC>"
-  socket_address     = "<host:port>"
-  username           = "<replace-with-username>"
-  password           = "<replace-with-password>"
-  ignore_certificate = "<replace-with-boolean-without-quotes-true-or-false>"
+  name               = "wl-asa"
+  connector_type     = "CDG"
+  socket_address     = "52.53.230.145:443"
+  username           = "admin"
+  password           = ""
+  ignore_certificate = true
 }


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-69564

### Description
- Add read token before creating the ASA device to check whether tenant is using new ASA model.
- Add corresponding metadata field when creating the device
- Add test to check payload contains the right metadata when feature flag is set and vice versa.
