### PR TITLE
fix(LH-70915): Use external-compute tokens to generate bootstrap data

### DIFF
--- a/client/connector/bootstrapdata.go
+++ b/client/connector/bootstrapdata.go
@@ -12,7 +12,7 @@ import (
 )
 
 func generateBootstrapData(ctx context.Context, client http.Client, sdcName string) (string, error) {
-	userToken, err := user.GetToken(ctx, client, user.NewGetTokenInput())
+	userToken, err := user.GetExternalComputeToken(ctx, client, user.NewGetTokenInput())
 	if err != nil {
 		return "", err
 	}

--- a/client/internal/url/url.go
+++ b/client/internal/url/url.go
@@ -70,6 +70,10 @@ func UserToken(baseUrl string) string {
 	return fmt.Sprintf("%s/anubis/rest/v1/oauth/token", baseUrl)
 }
 
+func ExternalComputeToken(baseUrl string) string {
+	return fmt.Sprintf("%s/anubis/rest/v1/oauth/token/external-compute", baseUrl)
+}
+
 func ReadSmartLicense(baseUrl string) string {
 	return fmt.Sprintf("%s/fmc/api/fmc_platform/v1/license/smartlicenses", baseUrl)
 }

--- a/client/user/token.go
+++ b/client/user/token.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/user/auth"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
@@ -19,6 +20,25 @@ func NewGetTokenInput() GetTokenInput {
 func GetToken(ctx context.Context, client http.Client, getTokenInp GetTokenInput) (GetTokenOutput, error) {
 
 	url := url.UserToken(client.BaseUrl())
+
+	req := client.NewPost(ctx, url, nil)
+
+	var getTokenOutp GetTokenOutput
+	if err := req.Send(&getTokenOutp); err != nil {
+		return GetTokenOutput{}, err
+	}
+
+	return getTokenOutp, nil
+}
+
+/*
+* This function will generate a new external-compute token. We use the external compute token to generate the CDO bootstrap data, because
+* an Anubis weirdness (which I have been assured is a feature, not a bug) results in calling `/token` returning the same token that it
+* was called with, because we allow only one token to exist for a given scope.
+ */
+func GetExternalComputeToken(ctx context.Context, client http.Client, getTokenInp GetTokenInput) (GetTokenOutput, error) {
+
+	url := url.ExternalComputeToken(client.BaseUrl())
 
 	req := client.NewPost(ctx, url, nil)
 

--- a/provider/examples/data-sources/cdfmc/example.tf
+++ b/provider/examples/data-sources/cdfmc/example.tf
@@ -15,17 +15,17 @@ data "cdo_cdfmc" "current" {
 }
 
 output "cdfmc_hostname" {
-    value = data.cdo_cdfmc.current.hostname
+  value = data.cdo_cdfmc.current.hostname
 }
 
 output "cdfmc_software_version" {
-    value = data.cdo_cdfmc.current.software_version
+  value = data.cdo_cdfmc.current.software_version
 }
 
 output "cdfmc_uid" {
-    value = data.cdo_cdfmc.current.id
+  value = data.cdo_cdfmc.current.id
 }
 
 output "cdfmc_domain_uuid" {
-    value = data.cdo_cdfmc.current.domain_uuid
+  value = data.cdo_cdfmc.current.domain_uuid
 }

--- a/provider/examples/resources/ftd/aws_ftd.tf
+++ b/provider/examples/resources/ftd/aws_ftd.tf
@@ -56,7 +56,7 @@ data "aws_internet_gateway" "default" {
 #########################################################################################################################
 
 provider "aws" {
-  region     = var.region
+  region = var.region
 }
 
 ###########################################################################################################################
@@ -254,7 +254,7 @@ resource "aws_route_table_association" "inside_association" {
 //External ip address creation 
 
 resource "aws_eip" "ftd01mgmt-EIP" {
-#   domain     = "vpc"
+  #   domain     = "vpc"
   depends_on = [aws_internet_gateway.int_gw, aws_instance.ftdv]
   tags = {
     "Name" = "FTDv-01 Management IP"
@@ -262,7 +262,7 @@ resource "aws_eip" "ftd01mgmt-EIP" {
 }
 
 resource "aws_eip" "ftd01outside-EIP" {
-#   domain     = "vpc"
+  #   domain     = "vpc"
   depends_on = [aws_internet_gateway.int_gw, aws_instance.ftdv]
   tags = {
     "Name" = "FTDv-01 outside IP"

--- a/provider/examples/resources/ftd/terraform.tfvars
+++ b/provider/examples/resources/ftd/terraform.tfvars
@@ -2,23 +2,23 @@
 # aws_access_key      = ""
 # aws_secret_key      = ""
 
-region              = "us-east-1"
+region = "us-east-1"
 
 // "Valid values for FTD_version are ftdv-7.0.5, ftdv-7.1.0, ftdv-7.2.4, ftdv-7.3.0."
-FTD_version         = "ftdv-7.3.0"
+FTD_version = "ftdv-7.3.0"
 
-vpc_name            = "CiscoFTDv-VPC"
-vpc_cidr            = "10.1.0.0/16"
+vpc_name = "CiscoFTDv-VPC"
+vpc_cidr = "10.1.0.0/16"
 
-mgmt_subnet         = "10.1.0.0/24"
-outside_subnet      = "10.1.1.0/24"
-diag_subnet         = "10.1.2.0/24"
-inside_subnet       = "10.1.3.0/24"
+mgmt_subnet    = "10.1.0.0/24"
+outside_subnet = "10.1.1.0/24"
+diag_subnet    = "10.1.2.0/24"
+inside_subnet  = "10.1.3.0/24"
 
-ftd01_mgmt_ip       =  "10.1.0.11"
-ftd01_outside_ip    =  "10.1.1.11"
-ftd01_diag_ip       =  "10.1.2.11"
-ftd01_inside_ip     =  "10.1.3.11"
+ftd01_mgmt_ip    = "10.1.0.11"
+ftd01_outside_ip = "10.1.1.11"
+ftd01_diag_ip    = "10.1.2.11"
+ftd01_inside_ip  = "10.1.3.11"
 
-create_igw = true
+create_igw   = true
 existing_vpc = false

--- a/provider/examples/resources/ftd/variables.tf
+++ b/provider/examples/resources/ftd/variables.tf
@@ -5,80 +5,80 @@
 # variable "aws_access_key" {}
 # variable "aws_secret_key" {}
 variable "admin_password" {
-    default = "Admin123"
+  default = "Admin123"
 }
 variable "region" {
-        default = "us-east-1"
+  default = "us-east-1"
 }
 
 variable "FTD_version" {
-    default = "ftdv-7.3.0"
-    validation {
-        condition     = contains(["ftdv-7.0.5", "ftdv-7.1.0", "ftdv-7.2.4","ftdv-7.3.0"], var.FTD_version)
-        error_message = "Valid values for var: FTD_version are (ftdv-7.0.5, ftdv-7.1.0, ftdv-7.2.4, ftdv-7.3.0)."
-    } 
-} 
+  default = "ftdv-7.3.0"
+  validation {
+    condition     = contains(["ftdv-7.0.5", "ftdv-7.1.0", "ftdv-7.2.4", "ftdv-7.3.0"], var.FTD_version)
+    error_message = "Valid values for var: FTD_version are (ftdv-7.0.5, ftdv-7.1.0, ftdv-7.2.4, ftdv-7.3.0)."
+  }
+}
 variable "existing_vpc" {
-    type    = bool
-    default = true
+  type    = bool
+  default = true
 }
 variable "create_igw" {
-    type    = bool
+  type = bool
 }
 variable "vpc_name" {
-    default = "Cisco-FTDv-VPC"
+  default = "Cisco-FTDv-VPC"
 }
 
 //Including the Avilability Zone
 variable "aws_az" {
-    default = "us-east-1a"
+  default = "us-east-1a"
 }
 
 //defining the VPC CIDR
 variable "vpc_cidr" {
-    default = "10.1.0.0/16"
+  default = "10.1.0.0/16"
 }
 
 // defining the subnets variables with the default value for Three Tier Architecure. 
 
 variable "mgmt_subnet" {
-    default = "10.1.0.0/24"
+  default = "10.1.0.0/24"
 }
 
 variable "ftd01_mgmt_ip" {
-    default = "10.1.0.11"
+  default = "10.1.0.11"
 }
 
 variable "ftd01_outside_ip" {
-    default = "10.1.1.11"
+  default = "10.1.1.11"
 }
 
 variable "ftd01_inside_ip" {
-    default = "10.1.3.11"
+  default = "10.1.3.11"
 }
-        
+
 variable "ftd01_diag_ip" {
-    default = "10.1.2.11"
-}        
+  default = "10.1.2.11"
+}
 
 variable "ftd01_dmz_ip" {
-    default = "10.1.4.11"
+  default = "10.1.4.11"
 }
 
 variable "diag_subnet" {
-    default = "10.1.2.0/24"
+  default = "10.1.2.0/24"
 }
 
 variable "outside_subnet" {
-    default = "10.1.1.0/24"
+  default = "10.1.1.0/24"
 }
 
 variable "dmz_subnet" {
-    default = "10.0.4.0/24"
+  default = "10.0.4.0/24"
 }
 
 variable "inside_subnet" {
-    default = "10.1.3.0/24"
+  default = "10.1.3.0/24"
 }
 
 variable "size" {

--- a/provider/examples/resources/sdc/sdc_example.tf
+++ b/provider/examples/resources/sdc/sdc_example.tf
@@ -24,5 +24,6 @@ output "sdc_uid" {
 }
 
 output "sdc_bootstrap_data" {
-  value = cdo_sdc.example.bootstrap_data
+  value     = cdo_sdc.example.bootstrap_data
+  sensitive = true
 }

--- a/provider/examples/resources/user_api_token/example.tf
+++ b/provider/examples/resources/user_api_token/example.tf
@@ -19,10 +19,10 @@ resource "cdo_user" "new_api_only_user" {
 }
 
 resource "cdo_api_token" "new_api_only_user_api_token" {
-    username = cdo_user.new_api_only_user.generated_username
+  username = cdo_user.new_api_only_user.generated_username
 }
 
 output "api_only_user_api_token_value" {
-    value = cdo_api_token.new_api_only_user_api_token.api_token
-    sensitive = true
+  value     = cdo_api_token.new_api_only_user_api_token.api_token
+  sensitive = true
 }


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70915

### Description

There is an Anubis weirdness by which only a single token can exist for a given scope (external-compute and fmc tokens are exceptions we deliberately engineered to work around this limitation which is a feature of some kind). So when you call `/oauth/token` with the API token fed in to the Terraform provider, you actually get back the same token you called with. When this token is passed into the bootstrap function of our SDC, the bootstrap method revokes the token after setting up the SDC. This nvalidates the token the terraform-provider is using, and we end up having to regenerate the token. In this PR, I switch to using the external-compute token instead for bootstrapping the SDC. (yes, this is a hack, and no Weilue, we are not going to "fix" this, there have been many discussions around this between Doron and me for months now :) ).


