### PR TITLE
Remove Support For Terraform Version <1.3 and add v1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,10 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.0.*'
-          - '1.1.*'
           - '1.2.*'
           - '1.3.*'
           - '1.4.*'
+          - '1.5.*'
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.2.*'
           - '1.3.*'
           - '1.4.*'
           - '1.5.*'


### PR DESCRIPTION
### Description

Siddhu mentioned Terraform 1.1 and 1.2 do not support a number of the AWS constructs we depend on to make stuff work in our labs; so there's no point supporting them.

