### PR TITLE
fix(LH-72127): SDC resource leak

### DIFF
--- a/client/connector/create_test.go
+++ b/client/connector/create_test.go
@@ -2,6 +2,7 @@ package connector_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -40,6 +41,14 @@ func TestCreate(t *testing.T) {
 		TokenType(tokenType).
 		Build()
 
+	validQueueReadyOutput := connector.NewConnectorOutputBuilder().
+		AsOnPremConnector().
+		WithUid(validCreateRequestOutput.Uid).
+		WithName(validCreateRequestOutput.Name).
+		WithTenantUid(validCreateRequestOutput.TenantUid).
+		WithCommunicationReady(true).
+		Build()
+
 	testCases := []struct {
 		testName   string
 		sdcName    string
@@ -60,6 +69,11 @@ func TestCreate(t *testing.T) {
 					"POST",
 					"/anubis/rest/v1/oauth/token/external-compute",
 					httpmock.NewJsonResponderOrPanic(200, validUserToken),
+				)
+				httpmock.RegisterResponder(
+					"GET",
+					fmt.Sprintf("/aegis/rest/v1/services/targets/proxies/%s", validQueueReadyOutput.Uid),
+					httpmock.NewJsonResponderOrPanic(200, validQueueReadyOutput),
 				)
 			},
 

--- a/client/connector/read.go
+++ b/client/connector/read.go
@@ -19,13 +19,14 @@ type ReadByNameInput struct {
 }
 
 type ReadOutput struct {
-	Uid              string          `json:"uid"`
-	Name             string          `json:"name"`
-	DefaultConnector bool            `json:"defaultLar"`
-	Cdg              bool            `json:"cdg"`
-	TenantUid        string          `json:"tenantUid"`
-	PublicKey        model.PublicKey `json:"larPublicKey"`
-	ConnectorStatus  status.Type     `json:"larStatus"`
+	Uid                       string          `json:"uid"`
+	Name                      string          `json:"name"`
+	DefaultConnector          bool            `json:"defaultLar"`
+	Cdg                       bool            `json:"cdg"`
+	TenantUid                 string          `json:"tenantUid"`
+	PublicKey                 model.PublicKey `json:"larPublicKey"`
+	ConnectorStatus           status.Type     `json:"larStatus"`
+	IsCommunicationQueueReady bool            `json:"snsSqs"`
 }
 
 func NewReadByUidInput(connectorUid string) *ReadByUidInput {

--- a/client/connector/readoutputbulider.go
+++ b/client/connector/readoutputbulider.go
@@ -51,6 +51,12 @@ func (builder *sdcReadOutputBuilder) WithTenantUid(tenantUid string) *sdcReadOut
 	return builder
 }
 
+func (builder *sdcReadOutputBuilder) WithCommunicationReady(ready bool) *sdcReadOutputBuilder {
+	builder.readOutput.IsCommunicationQueueReady = ready
+
+	return builder
+}
+
 func mustGenerateBase64PublicKey() string {
 	key, err := rsa.GenerateKey(rand.Reader, 512)
 	if err != nil {

--- a/provider/internal/connector/resource_test.go
+++ b/provider/internal/connector/resource_test.go
@@ -27,7 +27,6 @@ var testResource_NewName = acctest.MustOverrideFields(testSdcResource, map[strin
 var testResourceConfig_NewName = acctest.MustParseTemplate(testResourceTemplate, testResource_NewName)
 
 func TestAccSdcResource(t *testing.T) {
-	t.Skip("this test does not clean up sqs and sns correctly, skip until LH-72127 is resolved")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 acctest.PreCheckFunc(t),
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-72127

### Description
The SDC acceptance tests was leaking AWS SQS resource to be not deleted, because the test tear down too quickly, before the AWS SQS was ready, this PR waits for the queue to be ready during create operation.

I wanted to fix this in Aegis, but failed to find where to fix in Aegis so I just fix it here...
