### PR TITLE
fix(LH-71921): Make use of context in retry function

### DIFF
--- a/client/connector/connectoronboarding/create.go
+++ b/client/connector/connectoronboarding/create.go
@@ -25,6 +25,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	// wait for connector status to be "Active"
 	var readOutp connector.ReadOutput
 	err := retry.Do(
+		ctx,
 		UntilConnectorStatusIsActive(ctx, client, *connector.NewReadByNameInput(createInp.Name), &readOutp),
 		retry.NewOptionsBuilder().
 			Timeout(15*time.Minute). // usually takes ~3 minutes

--- a/client/connector/create.go
+++ b/client/connector/create.go
@@ -56,6 +56,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 
 	// 1.5 poll until SDC has SQS/SNS setup properly to communicate with backend
 	err := retry.Do(
+		ctx,
 		untilCommunicationQueueReady(ctx, client, *NewReadByUidInput(createOutp.Uid)),
 		retry.NewOptionsBuilder().Retries(10).
 			Logger(client.Logger).

--- a/client/device/asa/asaconfig/retry_test.go
+++ b/client/device/asa/asaconfig/retry_test.go
@@ -147,7 +147,7 @@ func TestAsaConfigUntilStateDone(t *testing.T) {
 			retryOptions := retry.DefaultOpts
 			retryOptions.Delay = 1 * time.Millisecond
 
-			err := retry.Do(UntilStateDone(context.Background(), *http.MustNewWithDefault("https://unittest.cdo.cisco.com", "a_valid_token"), testCase.targetUid), retryOptions)
+			err := retry.Do(context.Background(), UntilStateDone(context.Background(), *http.MustNewWithDefault("https://unittest.cdo.cisco.com", "a_valid_token"), testCase.targetUid), retryOptions)
 
 			testCase.assertFunc(err, t)
 		})

--- a/client/device/asa/create.go
+++ b/client/device/asa/create.go
@@ -129,7 +129,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	client.Logger.Println("waiting for asa config state done")
 
 	// poll until asa config state done
-	err = retry.Do(asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), *retry.NewOptionsWithLogger(client.Logger))
+	err = retry.Do(ctx, asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), *retry.NewOptionsWithLogger(client.Logger))
 
 	// error during polling, but we maybe able to handle it
 	if err != nil {
@@ -206,7 +206,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	// poll until asa config state done
 	client.Logger.Println("waiting for device to reach state done")
 
-	err = retry.Do(asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), *retry.NewOptionsWithLogger(client.Logger))
+	err = retry.Do(ctx, asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), *retry.NewOptionsWithLogger(client.Logger))
 	if err != nil {
 		return nil, &CreateError{
 			CreatedResourceId: createdResourceId,

--- a/client/device/asa/update.go
+++ b/client/device/asa/update.go
@@ -86,7 +86,7 @@ func Update(ctx context.Context, client http.Client, updateInp UpdateInput) (*Up
 				return nil, err
 			}
 
-			if err := retry.Do(asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), retry.DefaultOpts); err != nil {
+			if err := retry.Do(ctx, asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), retry.DefaultOpts); err != nil {
 				return nil, err
 			}
 		}
@@ -100,7 +100,7 @@ func Update(ctx context.Context, client http.Client, updateInp UpdateInput) (*Up
 				return nil, err
 			}
 
-			if err := retry.Do(asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), retry.DefaultOpts); err != nil {
+			if err := retry.Do(ctx, asaconfig.UntilStateDone(ctx, client, asaReadSpecOutp.SpecificUid), retry.DefaultOpts); err != nil {
 				return nil, err
 			}
 		}
@@ -115,7 +115,7 @@ func Update(ctx context.Context, client http.Client, updateInp UpdateInput) (*Up
 		return nil, err
 	}
 
-	if err := retry.Do(UntilStateDoneAndConnectivityOk(ctx, client, outp.Uid), retry.DefaultOpts); err != nil {
+	if err := retry.Do(ctx, UntilStateDoneAndConnectivityOk(ctx, client, outp.Uid), retry.DefaultOpts); err != nil {
 		return nil, err
 	}
 

--- a/client/device/cloudfmc/create.go
+++ b/client/device/cloudfmc/create.go
@@ -74,7 +74,9 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 
 	client.Logger.Println("waiting for fmce state machine to be done")
 
-	err = retry.Do(untilApplicationActive(ctx, client),
+	err = retry.Do(
+		ctx,
+		untilApplicationActive(ctx, client),
 		retry.NewOptionsBuilder().
 			Retries(-1).
 			Timeout(30*time.Minute). // usually takes about 15-20 minutes

--- a/client/device/cloudfmc/fmcconfig/retry.go
+++ b/client/device/cloudfmc/fmcconfig/retry.go
@@ -46,6 +46,7 @@ func UntilCreateDeviceRecordSuccess(ctx context.Context, client http.Client, cre
 		}
 		readInp := NewReadTaskStatusInput(createDeviceRecordInput.FmcDomainUid, createDeviceOutp.Metadata.Task.Id, createDeviceRecordInput.FmcHostname)
 		err = retry.Do(
+			ctx,
 			UntilTaskStatusSuccess(ctx, client, readInp),
 			retry.NewOptionsBuilder().
 				Retries(-1).

--- a/client/device/cloudftd/cloudftdonboarding/create.go
+++ b/client/device/cloudftd/cloudftdonboarding/create.go
@@ -123,6 +123,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 		Build()
 	var createOutp fmcconfig.CreateDeviceRecordOutput
 	err = retry.Do(
+		ctx,
 		fmcconfig.UntilCreateDeviceRecordSuccess(ctx, client, createDeviceInp, &createOutp),
 		retry.NewOptionsBuilder().
 			Retries(-1).
@@ -156,6 +157,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	}
 	// 4.3 wait until state machine done
 	err = retry.Do(
+		ctx,
 		cloudftd.UntilSpecificStateDone(
 			ctx,
 			client,

--- a/client/device/cloudftd/create.go
+++ b/client/device/cloudftd/create.go
@@ -154,7 +154,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 
 	// 8. wait for generate command available
 	var metadata Metadata
-	err = retry.Do(UntilGeneratedCommandAvailable(ctx, client, createOup.Uid, &metadata), *retry.NewOptionsWithLoggerAndRetries(client.Logger, 3))
+	err = retry.Do(ctx, UntilGeneratedCommandAvailable(ctx, client, createOup.Uid, &metadata), *retry.NewOptionsWithLoggerAndRetries(client.Logger, 3))
 	if err != nil {
 		return nil, err
 	}

--- a/client/device/cloudftd/delete.go
+++ b/client/device/cloudftd/delete.go
@@ -51,7 +51,7 @@ func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*De
 	}
 
 	// 4. wait until the delete cloud FTD state machine has started
-	err = retry.Do(statemachine.UntilStarted(ctx, client, fmcReadSpecificRes.SpecificUid, "fmceDeleteFtdcStateMachine"), retry.DefaultOpts)
+	err = retry.Do(ctx, statemachine.UntilStarted(ctx, client, fmcReadSpecificRes.SpecificUid, "fmceDeleteFtdcStateMachine"), retry.DefaultOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/client/device/ios/create.go
+++ b/client/device/ios/create.go
@@ -121,7 +121,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 		publicKey = &connectorReadRes.PublicKey
 	}
 
-	err = retry.Do(iosconfig.UntilState(ctx, client, deviceCreateOutp.Uid, state.PRE_READ_METADATA), *retry.NewOptionsWithLogger(client.Logger))
+	err = retry.Do(ctx, iosconfig.UntilState(ctx, client, deviceCreateOutp.Uid, state.PRE_READ_METADATA), *retry.NewOptionsWithLogger(client.Logger))
 	if err != nil {
 		return nil, &CreateError{
 			Err:               err,
@@ -149,7 +149,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 	// poll until ios config state done
 	client.Logger.Println("waiting for device to reach state done")
 
-	err = retry.Do(iosconfig.UntilState(ctx, client, deviceCreateOutp.Uid, state.DONE), *retry.NewOptionsWithLogger(client.Logger))
+	err = retry.Do(ctx, iosconfig.UntilState(ctx, client, deviceCreateOutp.Uid, state.DONE), *retry.NewOptionsWithLogger(client.Logger))
 	if err != nil {
 		return nil, &CreateError{
 			Err:               err,

--- a/client/device/ios/iosconfig/retry_test.go
+++ b/client/device/ios/iosconfig/retry_test.go
@@ -107,7 +107,7 @@ func TestIosConfigUntilState(t *testing.T) {
 			retryOptions := retry.DefaultOpts
 			retryOptions.Delay = 1 * time.Millisecond
 
-			err := retry.Do(UntilState(context.Background(), *http.MustNewWithDefault("https://unittest.cdo.cisco.com", "a_valid_token"), testCase.targetUid, state.DONE), retryOptions)
+			err := retry.Do(context.Background(), UntilState(context.Background(), *http.MustNewWithDefault("https://unittest.cdo.cisco.com", "a_valid_token"), testCase.targetUid, state.DONE), retryOptions)
 
 			testCase.assertFunc(err, t)
 		})

--- a/client/internal/goutil/goutil.go
+++ b/client/internal/goutil/goutil.go
@@ -1,5 +1,7 @@
 package goutil
 
+import "golang.org/x/exp/constraints"
+
 // AsPointer convert interface{} to *interface{}, if input is not nil
 func AsPointer(obj interface{}) *interface{} {
 	var ptr *interface{} = nil
@@ -12,4 +14,22 @@ func AsPointer(obj interface{}) *interface{} {
 // NewBoolPointer return a pointer of the given boolean value, this function is needed because you cant do &true or &false in golang
 func NewBoolPointer(value bool) *bool {
 	return &value
+}
+
+// Min return the smaller value of a and b
+// starting go 1.21, we can use builtin min
+func Min[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Max return the greater value of a and b
+// starting go 1.21, we can use builtin max
+func Max[T constraints.Ordered](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/client/internal/http/request.go
+++ b/client/internal/http/request.go
@@ -58,21 +58,23 @@ func NewRequest(config cdo.Config, httpClient *http.Client, logger *log.Logger, 
 // TODO: cancel retry when context done
 // output: if given, will unmarshal response body into this object, should be a pointer for it to be useful
 func (r *Request) Send(output any) error {
-	err := retry.Do(func() (bool, error) {
+	err := retry.Do(
+		context.Background(),
+		func() (bool, error) {
 
-		err := r.send(output)
-		if err != nil {
-			return false, err
-		}
-		return true, nil
+			err := r.send(output)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
 
-	}, *retry.NewOptions(
-		r.logger,
-		r.config.Timeout,
-		r.config.Delay,
-		r.config.Retries,
-		false,
-	))
+		}, *retry.NewOptions(
+			r.logger,
+			r.config.Timeout,
+			r.config.Delay,
+			r.config.Retries,
+			false,
+		))
 
 	return err
 }

--- a/client/internal/http/request.go
+++ b/client/internal/http/request.go
@@ -59,7 +59,7 @@ func NewRequest(config cdo.Config, httpClient *http.Client, logger *log.Logger, 
 // output: if given, will unmarshal response body into this object, should be a pointer for it to be useful
 func (r *Request) Send(output any) error {
 	err := retry.Do(
-		context.Background(),
+		context.Background(), // internal retry is not cancellable
 		func() (bool, error) {
 
 			err := r.send(output)

--- a/client/internal/http/request.go
+++ b/client/internal/http/request.go
@@ -59,7 +59,11 @@ func NewRequest(config cdo.Config, httpClient *http.Client, logger *log.Logger, 
 // output: if given, will unmarshal response body into this object, should be a pointer for it to be useful
 func (r *Request) Send(output any) error {
 	err := retry.Do(
-		context.Background(), // internal retry is not cancellable
+		// context.Background() will never cancel according to documentation
+		// we do not want to cancel here because this retry mechanism is intended to overcome
+		// the flaky CDO api, built into every request, and we probably do not want to cancel
+		// and fail due to flaky-ness, but if we want to cancel, there is no obvious bad side effect.
+		context.Background(),
 		func() (bool, error) {
 
 			err := r.send(output)

--- a/client/internal/retry/do.go
+++ b/client/internal/retry/do.go
@@ -96,7 +96,7 @@ func NewOptions(logger *log.Logger, timeout time.Duration, delay time.Duration, 
 func Do(ctx context.Context, retryFunc Func, opt Options) error {
 	// set up context
 	ctxToUse := ctx
-	if opt.Timeout > 0 {
+	if opt.Timeout >= 0 {
 		var cancel context.CancelFunc
 		ctxToUse, cancel = context.WithTimeout(ctx, opt.Timeout)
 		defer cancel()
@@ -118,7 +118,7 @@ func doInternal(ctx context.Context, retryFunc Func, opt Options) error {
 	// setup errors
 	// retryErrors[i] = nil: no error occur at this attempt
 	// retryErrors[i] != nil: error occur at this attempt
-	retryErrors := make([]error, goutil.Max(opt.Retries, 0)+1)
+	retryErrors := make([]error, goutil.Max(opt.Retries, 0)+1) // +1 because total attempts = retries + 1 initial attempt
 
 	for attempt := 0; attempt <= opt.Retries || opt.Retries < 0; attempt++ {
 		select {

--- a/client/internal/retry/do.go
+++ b/client/internal/retry/do.go
@@ -106,7 +106,7 @@ func Do(retryFunc Func, opt Options) error {
 	ok, err := retryFunc()
 	accumulatedErrs = append(accumulatedErrs, err)
 	if err != nil && opt.EarlyExitOnError {
-		return fmt.Errorf("error in initial retry, cause=%w", err)
+		return fmt.Errorf("error in retry func, cause=%w", err)
 	}
 	if ok {
 		return nil

--- a/client/internal/retry/do.go
+++ b/client/internal/retry/do.go
@@ -165,9 +165,7 @@ type retryInfo struct {
 	timeout bool
 }
 
-// retry sends a number to the given channel according to given delay and retries,
-// it will send retries+1 numbers to the channel, the number sent is the current retry attempt,
-// 0 indicate the first attempt, -1 indicate an early timeout during future delay.
+// retry sends a retryInfo to the given channel according to given delay and retries,
 func retry(ctx context.Context, c chan<- retryInfo, delay time.Duration, retries int) {
 	c <- retryInfo{attempt: 0, timeout: false}
 	for attempt := 1; attempt <= retries || retries < 0; attempt++ {

--- a/client/internal/retry/do.go
+++ b/client/internal/retry/do.go
@@ -85,7 +85,7 @@ func NewOptions(logger *log.Logger, timeout time.Duration, delay time.Duration, 
 }
 
 // Do run retry function until response of request satisfy check function, or ends early according to configuration.
-func Do(ctx context.Context, retryFunc Func, opt Options) error {
+func Do(retryFunc Func, opt Options) error {
 
 	startTime := time.Now()
 	endTime := startTime.Add(opt.Timeout)

--- a/client/internal/retry/do_test.go
+++ b/client/internal/retry/do_test.go
@@ -66,6 +66,21 @@ func TestRetryContextOrOptionsErrors(t *testing.T) {
 			// retryOptions.Timeout is less than retries * delay or context.Timeout
 			expectedError: retry.TimeoutError,
 		},
+		{
+			testName:       "Should timeout immediately without any attempt when retry options timeout is 0",
+			contextTimeout: time.Second,
+			retryOptions: retry.Options{
+				Timeout:          0,
+				Delay:            time.Second,
+				Retries:          100,
+				Logger:           log.Default(),
+				EarlyExitOnError: false,
+			},
+			retryFunc: func() (bool, error) {
+				return true, nil // return true so that no error will occur if attempt occurred
+			},
+			expectedError: retry.TimeoutError,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/client/internal/retry/do_test.go
+++ b/client/internal/retry/do_test.go
@@ -1,0 +1,222 @@
+package retry_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestRetryContextOrOptionsErrors(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		contextTimeout time.Duration
+		retryOptions   retry.Options
+		retryFunc      retry.Func
+		expectedError  retry.ErrorType
+	}{
+		{
+			testName:       "Should retries exceed when retries finishes before any timeout occur",
+			contextTimeout: time.Second,
+			retryOptions: retry.Options{
+				Timeout:          time.Second,
+				Delay:            2 * time.Millisecond,
+				Retries:          2,
+				Logger:           log.Default(),
+				EarlyExitOnError: false,
+			},
+			retryFunc: func() (bool, error) {
+				return false, nil
+			},
+			// retries * delay is less than context.Timeout or retryOptions.Timeout
+			expectedError: retry.RetriesExceededError,
+		},
+		{
+			testName:       "Should timeout when context timeout before retries or retry options timeout occur",
+			contextTimeout: 2 * time.Millisecond,
+			retryOptions: retry.Options{
+				Timeout:          time.Second,
+				Delay:            time.Millisecond,
+				Retries:          1000,
+				Logger:           log.Default(),
+				EarlyExitOnError: false,
+			},
+			retryFunc: func() (bool, error) {
+				return false, nil
+			},
+			// context timeout is less than retries * delay or retryOptions.Timeout
+			expectedError: retry.TimeoutError,
+		},
+		{
+			testName:       "Should timeout when retry options timeout before retries or context retry timeout occur",
+			contextTimeout: time.Second,
+			retryOptions: retry.Options{
+				Timeout:          5 * time.Millisecond,
+				Delay:            2 * time.Millisecond,
+				Retries:          1000,
+				Logger:           log.Default(),
+				EarlyExitOnError: false,
+			},
+			retryFunc: func() (bool, error) {
+				return false, nil
+			},
+			// retryOptions.Timeout is less than retries * delay or context.Timeout
+			expectedError: retry.TimeoutError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			retryCtx, cancel := context.WithTimeout(context.Background(), testCase.contextTimeout)
+			defer cancel()
+
+			err := retry.Do2(retryCtx, testCase.retryFunc, testCase.retryOptions)
+
+			assert.ErrorIs(t, err, testCase.expectedError)
+		})
+	}
+}
+
+func TestRetryFunctionSuccess(t *testing.T) {
+
+	testCases := []int{1, 10, 100} // the varying number of attempts before retry function returns success
+
+	for _, expectedAttempts := range testCases {
+		t.Run(
+			fmt.Sprintf("Should terminate correctly when it ends successfully after retrying %d times", expectedAttempts),
+			func(t *testing.T) {
+				var actualAttempt = 0
+				err := retry.Do2(context.Background(), func() (bool, error) {
+					actualAttempt++
+					return actualAttempt == expectedAttempts, nil
+				}, retry.Options{
+					Timeout:          time.Second,
+					Delay:            0,
+					Retries:          expectedAttempts,
+					Logger:           log.Default(),
+					EarlyExitOnError: true,
+				})
+
+				assert.Nil(t, err)
+				assert.Equal(t, expectedAttempts, actualAttempt)
+			})
+	}
+}
+
+func TestRetryFunctionError(t *testing.T) {
+
+	testCases := []int{1, 10, 100} // the varying number of attempts before retry function returns error
+
+	for _, errorAttempt := range testCases {
+		t.Run(
+			fmt.Sprintf("Should ends correctly when error occur after retrying %d times", errorAttempt),
+			func(t *testing.T) {
+				var actualAttempt = 0
+				err := retry.Do2(
+					context.Background(),
+					func() (bool, error) {
+						actualAttempt++
+						if actualAttempt < errorAttempt {
+							return false, nil
+						} else {
+							return false, fmt.Errorf("error occured")
+						}
+					},
+					retry.Options{
+						Timeout:          time.Second,
+						Delay:            0,
+						Retries:          errorAttempt,
+						Logger:           log.Default(),
+						EarlyExitOnError: true,
+					})
+
+				assert.NotNil(t, err)
+				assert.Equal(t, errorAttempt, actualAttempt)
+			})
+	}
+}
+
+func TestRetryEarlyExitOnError(t *testing.T) {
+
+	// number of times to return errors
+	testCases := []int{1, 10, 100}
+	// setup errors so that every time the retry func will return different error
+	testErrors := make([]error, 100)
+	for i := 0; i < cap(testErrors); i++ {
+		testErrors[i] = fmt.Errorf("error %d", i)
+	}
+
+	for _, attempts := range testCases {
+		errorIndex := 0
+		t.Run(
+			fmt.Sprintf("Should return accumulated errors after retrying %d times", attempts),
+			func(t *testing.T) {
+				err := retry.Do2(
+					context.Background(),
+					func() (bool, error) {
+						defer func() { errorIndex++ }()
+						return false, testErrors[errorIndex] // return different errors
+					},
+					retry.Options{
+						Timeout:          time.Second,
+						Delay:            0,
+						Retries:          attempts - 1,
+						Logger:           log.Default(),
+						EarlyExitOnError: false,
+					})
+
+				assert.NotNil(t, err)
+				for i := 0; i < attempts; i++ {
+					// assert errors are indeed returned
+					assert.ErrorIs(t, err, testErrors[i])
+				}
+			})
+	}
+}
+
+func TestRetryShouldAttemptOnceBeforeRetry(t *testing.T) {
+
+	attempts := 0
+	err := retry.Do2(
+		context.Background(),
+		func() (bool, error) {
+			attempts++
+			return false, nil
+		},
+		retry.Options{
+			Timeout:          time.Second,
+			Delay:            0,
+			Retries:          0, // no retries will happen
+			Logger:           log.Default(),
+			EarlyExitOnError: false,
+		})
+
+	assert.ErrorIs(t, err, retry.RetriesExceededError)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestRetryShouldTimeoutIfWillTimeoutAfterDelay(t *testing.T) {
+
+	attempts := 0
+	startTime := time.Now()
+	err := retry.Do2(
+		context.Background(),
+		func() (bool, error) {
+			attempts++
+			return false, nil
+		},
+		retry.Options{
+			Timeout:          500 * time.Millisecond, // smaller than delay so that it will terminate early
+			Delay:            time.Second,
+			Retries:          1,
+			Logger:           log.Default(),
+			EarlyExitOnError: false,
+		})
+
+	assert.ErrorIs(t, err, retry.TimeoutError)
+	assert.Less(t, time.Since(startTime), 300*time.Millisecond) // time since start should be smaller than delay, to assure that no delay actually took place
+	assert.Equal(t, 1, attempts)
+}

--- a/client/internal/retry/do_test.go
+++ b/client/internal/retry/do_test.go
@@ -81,6 +81,21 @@ func TestRetryContextOrOptionsErrors(t *testing.T) {
 			},
 			expectedError: retry.TimeoutError,
 		},
+		{
+			testName:       "Should error if retry func errored",
+			contextTimeout: time.Second,
+			retryOptions: retry.Options{
+				Timeout:          time.Second,
+				Delay:            0,
+				Retries:          0,
+				Logger:           log.Default(),
+				EarlyExitOnError: true,
+			},
+			retryFunc: func() (bool, error) {
+				return false, fmt.Errorf("intentional test error occurred")
+			},
+			expectedError: retry.FuncError,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/client/internal/retry/error.go
+++ b/client/internal/retry/error.go
@@ -1,0 +1,36 @@
+package retry
+
+import (
+	"fmt"
+)
+
+// ErrorType is the base error interface of the retry package
+type ErrorType interface {
+	Error() string
+}
+
+// errorType is the implementing class
+type errorType struct{}
+
+func (err errorType) Error() string {
+	return "retry error"
+}
+
+// Error facilitates `errors.Is(err, retry.Error)`
+var Error = errorType{}
+
+// TimeoutError facilitates `errors.Is(err, retry.TimeoutError)`
+var TimeoutError = fmt.Errorf("%w: timeout", Error)
+
+// newTimeoutErrorf is used within this package to create new timeout error
+func newTimeoutErrorf(format string, a ...any) ErrorType {
+	return fmt.Errorf("%w: %w", TimeoutError, fmt.Errorf(format, a...))
+}
+
+// RetriesExceededError facilitates `errors.Is(err, retry.RetriesExceededError)`
+var RetriesExceededError = fmt.Errorf("%w: retries exceeded", Error)
+
+// newRetriesExceededErrorf is used within this package to create new RetriesExceededErrorType error
+func newRetriesExceededErrorf(format string, a ...any) ErrorType {
+	return fmt.Errorf("%w: %w", RetriesExceededError, fmt.Errorf(format, a...))
+}

--- a/client/internal/retry/error.go
+++ b/client/internal/retry/error.go
@@ -35,10 +35,18 @@ func newRetriesExceededErrorf(format string, a ...any) ErrorType {
 	return fmt.Errorf("%w: %w", RetriesExceededError, fmt.Errorf(format, a...))
 }
 
-// ContextCancelledError facilitates `errors.Is(err, retry.RetriesExceededError)`.
+// ContextCancelledError facilitates `errors.Is(err, retry.ContextCancelledError)`.
 var ContextCancelledError = fmt.Errorf("%w: context cancelled", Error)
 
-// newContextCancelledErrorf is used within this package to create new RetriesExceededError.
+// newContextCancelledErrorf is used within this package to create new ContextCancelledError.
 func newContextCancelledErrorf(format string, a ...any) ErrorType {
 	return fmt.Errorf("%w: %w", ContextCancelledError, fmt.Errorf(format, a...))
+}
+
+// FuncError facilitates `errors.Is(err, retry.FuncError)`.
+var FuncError = fmt.Errorf("%w: retry function errored", Error)
+
+// newFuncErrorf is used within this package to create new FuncError.
+func newFuncErrorf(format string, a ...any) ErrorType {
+	return fmt.Errorf("%w: %w", FuncError, fmt.Errorf(format, a...))
 }

--- a/client/internal/retry/error.go
+++ b/client/internal/retry/error.go
@@ -4,33 +4,41 @@ import (
 	"fmt"
 )
 
-// ErrorType is the base error interface of the retry package
+// ErrorType is the base error interface of the retry package.
 type ErrorType interface {
 	Error() string
 }
 
-// errorType is the implementing class
+// errorType is the implementing class.
 type errorType struct{}
 
 func (err errorType) Error() string {
 	return "retry error"
 }
 
-// Error facilitates `errors.Is(err, retry.Error)`
+// Error facilitates `errors.Is(err, retry.Error)`.
 var Error = errorType{}
 
-// TimeoutError facilitates `errors.Is(err, retry.TimeoutError)`
+// TimeoutError facilitates `errors.Is(err, retry.TimeoutError)`.
 var TimeoutError = fmt.Errorf("%w: timeout", Error)
 
-// newTimeoutErrorf is used within this package to create new timeout error
+// newTimeoutErrorf is used within this package to create new TimeoutError.
 func newTimeoutErrorf(format string, a ...any) ErrorType {
 	return fmt.Errorf("%w: %w", TimeoutError, fmt.Errorf(format, a...))
 }
 
-// RetriesExceededError facilitates `errors.Is(err, retry.RetriesExceededError)`
+// RetriesExceededError facilitates `errors.Is(err, retry.RetriesExceededError)`.
 var RetriesExceededError = fmt.Errorf("%w: retries exceeded", Error)
 
-// newRetriesExceededErrorf is used within this package to create new RetriesExceededErrorType error
+// newRetriesExceededErrorf is used within this package to create new RetriesExceededError.
 func newRetriesExceededErrorf(format string, a ...any) ErrorType {
 	return fmt.Errorf("%w: %w", RetriesExceededError, fmt.Errorf(format, a...))
+}
+
+// ContextCancelledError facilitates `errors.Is(err, retry.RetriesExceededError)`.
+var ContextCancelledError = fmt.Errorf("%w: context cancelled", Error)
+
+// newContextCancelledErrorf is used within this package to create new RetriesExceededError.
+func newContextCancelledErrorf(format string, a ...any) ErrorType {
+	return fmt.Errorf("%w: %w", ContextCancelledError, fmt.Errorf(format, a...))
 }

--- a/provider/internal/device/ftd/resource.go
+++ b/provider/internal/device/ftd/resource.go
@@ -191,8 +191,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	resp.State.RemoveResource(ctx)
-
 	// 3. save data into terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 	tflog.Trace(ctx, "read FTD resource done")

--- a/provider/internal/device/ftd/resource.go
+++ b/provider/internal/device/ftd/resource.go
@@ -191,6 +191,8 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
+	resp.State.RemoveResource(ctx)
+
 	// 3. save data into terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 	tflog.Trace(ctx, "read FTD resource done")


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-71921

### Description
Re-implement retry mechanism to consider the case of `context`, so that when `context` is cancelled, we stop retrying.

**Main files to look at**
- `client/internal/retry/do.go`
- `client/internal/retry/do_test.go`
- other files are just adding the `context` parameters