### PR TITLE
ci(LH-70847): automatically tag new version on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: go test -v -cover ./...
         timeout-minutes: 10
   trigger-release:
-    needs: [acceptance-tests, unit-testi]
+    needs: [acceptance-tests, unit-test]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,18 @@ jobs:
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2
-      - name: Create and push tag
+      - name: Generate tag
+        id: generate_tag
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: true
-          append_to_pre_release_tag: ""
+      - name: Create tag
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
+          custom_tag: ${{ steps.generate_tag.outputs.new_version }}
 #  release:
 #    if: github.ref_type == 'tag'
 #    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         timeout-minutes: 10
   trigger-release:
     needs: [unit-test]
-    if: github.ref == 'LH-70847-ci-release'
+    if: github.ref == 'refs/heads/LH-70847-ci-release'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,31 +129,42 @@ jobs:
           ASA_RESOURCE_SDC_PASSWORD: ${{ secrets.ASA_RESOURCE_SDC_PASSWORD }}
         run: go test -v -cover ./...
         timeout-minutes: 10
-  release:
-    if: github.ref_type == 'tag'
+  trigger-release:
+    needs: [acceptance-tests, unit-test]
+    if: github.ref == 'LH-70847-ci-release'
     runs-on: ubuntu-latest
-    needs: [unit-test]
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - name: Checkout repository code
+        uses: actions/checkout@v2
+      - name: Create and push tag
+        uses: mathieudutour/github-tag-action@v6.1
         with:
-          # Allow goreleaser to access older tag information.
-          fetch-depth: 0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-        with:
-          go-version: '1.20'
-          cache: true
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
-        id: import_gpg
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
-        with:
-          args: release --clean
-          workdir: provider
-        env:
-          # GitHub sets the GITHUB_TOKEN secret automatically.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+#  release:
+#    if: github.ref_type == 'tag'
+#    runs-on: ubuntu-latest
+#    needs: [acceptance-tests, unit-test]
+#    steps:
+#      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+#        with:
+#          # Allow goreleaser to access older tag information.
+#          fetch-depth: 0
+#      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+#        with:
+#          go-version: '1.20'
+#          cache: true
+#      - name: Import GPG key
+#        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
+#        id: import_gpg
+#        with:
+#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+#          passphrase: ${{ secrets.PASSPHRASE }}
+#      - name: Run GoReleaser
+#        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+#        with:
+#          args: release --clean
+#          workdir: provider
+#        env:
+#          # GitHub sets the GITHUB_TOKEN secret automatically.
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'LH-70847-ci-release'
     tags:
       - 'v*'
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,8 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
+          append_to_pre_release_tag: ""
 #  release:
 #    if: github.ref_type == 'tag'
 #    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: go test -v -cover ./...
         timeout-minutes: 10
   trigger-release:
-    needs: [acceptance-tests, unit-test]
+    needs: [unit-test]
     if: github.ref == 'LH-70847-ci-release'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'LH-70847-ci-release'
     tags:
       - 'v*'
 env:
@@ -131,7 +130,7 @@ jobs:
         run: go test -v -cover ./...
         timeout-minutes: 10
   trigger-release:
-    needs: [ acceptance-tests, unit-test ]
+    needs: [acceptance-tests, unit-testi]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -144,7 +143,7 @@ jobs:
   release:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
-    needs: [ acceptance-tests, unit-test ]
+    needs: [unit-test]
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,49 +131,41 @@ jobs:
         run: go test -v -cover ./...
         timeout-minutes: 10
   trigger-release:
-    needs: [unit-test]
-    if: github.ref == 'refs/heads/LH-70847-ci-release'
+    needs: [ acceptance-tests, unit-test ]
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2
-      - name: Generate tag
-        id: generate_tag
+      - name: Create and push tag
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: true
-      - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.1
+  release:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    needs: [ acceptance-tests, unit-test ]
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: true
-          custom_tag: ${{ steps.generate_tag.outputs.new_version }}
-#  release:
-#    if: github.ref_type == 'tag'
-#    runs-on: ubuntu-latest
-#    needs: [acceptance-tests, unit-test]
-#    steps:
-#      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-#        with:
-#          # Allow goreleaser to access older tag information.
-#          fetch-depth: 0
-#      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-#        with:
-#          go-version: '1.20'
-#          cache: true
-#      - name: Import GPG key
-#        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
-#        id: import_gpg
-#        with:
-#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-#          passphrase: ${{ secrets.PASSPHRASE }}
-#      - name: Run GoReleaser
-#        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
-#        with:
-#          args: release --clean
-#          workdir: provider
-#        env:
-#          # GitHub sets the GITHUB_TOKEN secret automatically.
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.20'
+          cache: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          args: release --clean
+          workdir: provider
+        env:
+          # GitHub sets the GITHUB_TOKEN secret automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ If you make any changes to the resources and data sources provided by this provi
 go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name cdo --rendered-provider-name "CDO Provider" --rendered-website-dir ../docs
 ```
 
-## Releasing
+## Releasing Manually
+> **Note**: Tags and releases are automatically done in GitHub action when pushed/merged PR into main branch and checks passed, there is no need for releasing manually in normal scenario.
 
-To release a new version of the Terraform CDO Provider, perform the following steps.
+To release a new version of the Terraform CDO Provider manually, perform the following steps.
 
 - Checkout main branch.
 - List current available tags: `git tag`.


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70847

### Description
This PR adds a job to the Github action workflow to create and push tag automatically on push into main branch and tests passes. Then it should trigger our already exist release job to actually do the release based on the new tag.
