### PR TITLE
ci(LH-70847): Fix github action trigger-release dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: go test -v -cover ./...
         timeout-minutes: 10
   trigger-release:
-    needs: [acceptance-tests, unit-test]
+    needs: [acceptance-test, unit-test]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-70847

### Description
Fix a typo that cause github action failed to run