### PR TITLE
fix(LH-72600): Address CodeQL RSA bits min requirement

### DIFF
--- a/client/connector/readoutputbulider.go
+++ b/client/connector/readoutputbulider.go
@@ -58,7 +58,7 @@ func (builder *sdcReadOutputBuilder) WithCommunicationReady(ready bool) *sdcRead
 }
 
 func mustGenerateBase64PublicKey() string {
-	key, err := rsa.GenerateKey(rand.Reader, 512)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-72600

### Description
Changed 512 to 2048 to make CodeQL happy, it does not matter because it is used in unit test only.

See also: https://github.com/CiscoDevNet/terraform-provider-cdo/security/code-scanning/1