### PR TITLE
feat(LH-72231): SEC Resource

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ package client
 import (
 	"context"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/connector/connectoronboarding"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/connector/sec"
 	"net/http"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/connector"
@@ -222,4 +223,20 @@ func (c *Client) ReadConnectorOnboarding(ctx context.Context, inp connectoronboa
 
 func (c *Client) DeleteConnectorOnboarding(ctx context.Context, inp connectoronboarding.DeleteInput) (*connectoronboarding.DeleteOutput, error) {
 	return connectoronboarding.Delete(ctx, c.client, inp)
+}
+
+func (c *Client) CreateSec(ctx context.Context, inp sec.CreateInput) (*sec.CreateOutput, error) {
+	return sec.Create(ctx, c.client, inp)
+}
+
+func (c *Client) UpdateSec(ctx context.Context, inp sec.UpdateInput) (*sec.UpdateOutput, error) {
+	return sec.Update(ctx, c.client, inp)
+}
+
+func (c *Client) DeleteSec(ctx context.Context, inp sec.DeleteInput) (*sec.DeleteOutput, error) {
+	return sec.Delete(ctx, c.client, inp)
+}
+
+func (c *Client) ReadSec(ctx context.Context, inp sec.ReadInput) (*sec.ReadOutput, error) {
+	return sec.Read(ctx, c.client, inp)
 }

--- a/client/connector/sec/bootstrapdata.go
+++ b/client/connector/sec/bootstrapdata.go
@@ -1,0 +1,28 @@
+package sec
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/user"
+)
+
+func ComputeEventOnlyBootstrapData(secName, accessToken, tenantName, baseUrl, host string) string {
+	bootstrapUrl := fmt.Sprintf("%s/connector/bootstrap/%s/%s", baseUrl, tenantName, secName)
+
+	rawBootstrapData := fmt.Sprintf("CDO_TOKEN=%q\nCDO_DOMAIN=%q\nCDO_TENANT=%q\nCDO_BOOTSTRAP_URL=%q\nONLY_EVENTING=\"true\"\n", accessToken, host, tenantName, bootstrapUrl)
+
+	bootstrapData := base64.StdEncoding.EncodeToString([]byte(rawBootstrapData))
+
+	return bootstrapData
+}
+
+func generateBootstrapData(ctx context.Context, client http.Client, secName string) (string, error) {
+	userToken, err := user.GetToken(ctx, client, user.NewGetTokenInput())
+	if err != nil {
+		return "", err
+	}
+
+	return ComputeEventOnlyBootstrapData(secName, userToken.AccessToken, userToken.TenantName, client.BaseUrl(), client.Host()), nil
+}

--- a/client/connector/sec/create.go
+++ b/client/connector/sec/create.go
@@ -1,0 +1,80 @@
+package sec
+
+import (
+	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
+	"time"
+)
+
+type CreateInput struct{}
+
+type CreateOutput struct {
+	Uid              string
+	Name             string
+	SecBootstrapData string
+	CdoBoostrapData  string
+}
+
+type createSecBody struct {
+	QueueTriggerState string `json:"queueTriggerState"`
+}
+
+func Create(ctx context.Context, client http.Client, createInp CreateInput) (*CreateOutput, error) {
+
+	// 1. create new sec
+	createUrl := url.CreateSec(client.BaseUrl())
+	createBody := createSecBody{QueueTriggerState: "ONBOARD_EVENT_STREAMER"}
+	req := client.NewPost(ctx, createUrl, createBody)
+	var createReqOutput CreateOutput
+	if err := req.Send(&createReqOutput); err != nil {
+		return nil, err
+	}
+
+	// 2. wait for state machine finish
+	err := retry.Do(
+		ctx,
+		statemachine.UntilDone(ctx, client, createReqOutput.Uid, "eventingPushRequest"),
+		retry.NewOptionsBuilder().
+			Message("Waiting for SEC to be created...").
+			Logger(client.Logger).
+			EarlyExitOnError(true).
+			Timeout(5*time.Minute).
+			Retries(-1).
+			Delay(time.Second).
+			Build(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	// 3. get sec bootstrap data
+	readOutput, err := Read(ctx, client, NewReadInputBuilder().Uid(createReqOutput.Uid).Build())
+	if err != nil {
+		return nil, err
+	}
+	secBootstrapData := readOutput.BootStrapData
+
+	// 4. generate cdo bootstrap data
+	cdoBootstrapData, err := generateBootstrapData(ctx, client, readOutput.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. re-read the sec for updated name
+	readOutp, err := Read(ctx, client, NewReadInputBuilder().Uid(createReqOutput.Uid).Build())
+	if err != nil {
+		return nil, err
+	}
+
+	// done, create output
+	createOutput := CreateOutput{
+		Uid:              createReqOutput.Uid,
+		Name:             readOutp.Name,
+		SecBootstrapData: secBootstrapData,
+		CdoBoostrapData:  cdoBootstrapData,
+	}
+
+	return &createOutput, nil
+}

--- a/client/connector/sec/create_inputbuilder.go
+++ b/client/connector/sec/create_inputbuilder.go
@@ -1,0 +1,15 @@
+package sec
+
+type CreateInputBuilder struct {
+	createInput *CreateInput
+}
+
+func NewCreateInputBuilder() *CreateInputBuilder {
+	createInput := &CreateInput{}
+	b := &CreateInputBuilder{createInput: createInput}
+	return b
+}
+
+func (b *CreateInputBuilder) Build() CreateInput {
+	return *b.createInput
+}

--- a/client/connector/sec/create_test.go
+++ b/client/connector/sec/create_test.go
@@ -1,4 +1,4 @@
-package examples_test
+package sec_test
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestExampleCreate(t *testing.T) {
+func TestSECCreate(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 

--- a/client/connector/sec/delete.go
+++ b/client/connector/sec/delete.go
@@ -1,0 +1,26 @@
+package sec
+
+import (
+	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
+)
+
+type DeleteInput struct {
+	Uid string
+}
+
+type DeleteOutput struct {
+}
+
+func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*DeleteOutput, error) {
+
+	deleteUrl := url.DeleteSec(client.BaseUrl(), deleteInp.Uid)
+	deleteReq := client.NewDelete(ctx, deleteUrl)
+	var deleteOutput DeleteOutput
+	if err := deleteReq.Send(&deleteOutput); err != nil {
+		return nil, err
+	}
+
+	return &deleteOutput, nil
+}

--- a/client/connector/sec/delete_inputbuilder.go
+++ b/client/connector/sec/delete_inputbuilder.go
@@ -1,0 +1,20 @@
+package sec
+
+type DeleteInputBuilder struct {
+	deleteInput *DeleteInput
+}
+
+func NewDeleteInputBuilder() *DeleteInputBuilder {
+	deleteInput := &DeleteInput{}
+	b := &DeleteInputBuilder{deleteInput: deleteInput}
+	return b
+}
+
+func (b *DeleteInputBuilder) Uid(uid string) *DeleteInputBuilder {
+	b.deleteInput.Uid = uid
+	return b
+}
+
+func (b *DeleteInputBuilder) Build() DeleteInput {
+	return *b.deleteInput
+}

--- a/client/connector/sec/read.go
+++ b/client/connector/sec/read.go
@@ -1,0 +1,30 @@
+package sec
+
+import (
+	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
+)
+
+type ReadInput struct {
+	Uid string
+}
+
+type ReadOutput struct {
+	Name            string `json:"name"`
+	Uid             string `json:"uid"`
+	BootStrapData   string `json:"bootstrapData"`
+	TokenExpiryTime int64  `json:"tokenExpiryTime"`
+}
+
+func Read(ctx context.Context, client http.Client, readInp ReadInput) (*ReadOutput, error) {
+
+	readUrl := url.ReadSec(client.BaseUrl(), readInp.Uid)
+	readReq := client.NewGet(ctx, readUrl)
+	var readOutput ReadOutput
+	if err := readReq.Send(&readOutput); err != nil {
+		return nil, err
+	}
+
+	return &readOutput, nil
+}

--- a/client/connector/sec/read_inputbuilder.go
+++ b/client/connector/sec/read_inputbuilder.go
@@ -1,0 +1,20 @@
+package sec
+
+type ReadInputBuilder struct {
+	readInput *ReadInput
+}
+
+func NewReadInputBuilder() *ReadInputBuilder {
+	readInput := &ReadInput{}
+	b := &ReadInputBuilder{readInput: readInput}
+	return b
+}
+
+func (b *ReadInputBuilder) Uid(uid string) *ReadInputBuilder {
+	b.readInput.Uid = uid
+	return b
+}
+
+func (b *ReadInputBuilder) Build() ReadInput {
+	return *b.readInput
+}

--- a/client/connector/sec/update.go
+++ b/client/connector/sec/update.go
@@ -1,4 +1,4 @@
-package examples
+package sec
 
 import (
 	"context"
@@ -13,7 +13,7 @@ type UpdateOutput struct {
 
 func Update(ctx context.Context, client http.Client, updateInp UpdateInput) (*UpdateOutput, error) {
 
-	// TODO
+	// intentional empty, I don't know what update we can do on an SEC
 
-	return nil, nil
+	return &UpdateOutput{}, nil
 }

--- a/client/connector/sec/update_inputbuilder.go
+++ b/client/connector/sec/update_inputbuilder.go
@@ -1,0 +1,15 @@
+package sec
+
+type UpdateInputBuilder struct {
+	updateInput *UpdateInput
+}
+
+func NewUpdateInputBuilder() *UpdateInputBuilder {
+	updateInput := &UpdateInput{}
+	b := &UpdateInputBuilder{updateInput: updateInput}
+	return b
+}
+
+func (b *UpdateInputBuilder) Build() UpdateInput {
+	return *b.updateInput
+}

--- a/client/device/asa/asaconfig/read.go
+++ b/client/device/asa/asaconfig/read.go
@@ -3,6 +3,7 @@ package asaconfig
 import (
 	"context"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
@@ -14,7 +15,7 @@ type ReadInput struct {
 
 type ReadOutput struct {
 	Uid                 string               `json:"uid"`
-	State               string               `json:"state"`
+	State               state.Type           `json:"state"`
 	StateMachineDetails statemachine.Details `json:"stateMachineDetails"`
 }
 

--- a/client/device/asa/asaconfig/retry.go
+++ b/client/device/asa/asaconfig/retry.go
@@ -2,12 +2,10 @@ package asaconfig
 
 import (
 	"context"
-	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
-	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
-	"strings"
-
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 )
 
 func UntilStateDone(ctx context.Context, client http.Client, specificUid string) retry.Func {
@@ -26,16 +24,16 @@ func UntilStateDone(ctx context.Context, client http.Client, specificUid string)
 		}
 
 		client.Logger.Printf("asa config state=%s\n", readOutp.State)
-		if strings.EqualFold(readOutp.State, state.DONE) {
+		if readOutp.State == state.DONE {
 			return true, nil
 		}
-		if strings.EqualFold(readOutp.State, state.ERROR) {
+		if readOutp.State == state.ERROR {
 			return false, statemachine.NewWorkflowErrorFromDetails(readOutp.StateMachineDetails)
 		}
-		if strings.EqualFold(readOutp.State, state.BAD_CREDENTIALS) {
+		if readOutp.State == state.BAD_CREDENTIALS {
 			return false, statemachine.NewWorkflowErrorf("Bad Credentials")
 		}
-		if strings.EqualFold(readOutp.State, state.PRE_WAIT_FOR_USER_TO_UPDATE_CREDS) {
+		if readOutp.State == state.PRE_WAIT_FOR_USER_TO_UPDATE_CREDS {
 			return false, statemachine.NewWorkflowErrorf("Bad Credentials")
 		}
 		return false, nil

--- a/client/device/asa/asaconfig/update.go
+++ b/client/device/asa/asaconfig/update.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/crypto"
-	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model"
-	"strings"
-
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 )
 
 type UpdateInput struct {
@@ -16,14 +15,14 @@ type UpdateInput struct {
 	Username    string
 	Password    string
 	PublicKey   *model.PublicKey
-	State       string
+	State       state.Type
 }
 
 type UpdateOutput struct {
 	Uid string `json:"uid"`
 }
 
-func NewUpdateInput(specificUid string, username string, password string, publicKey *model.PublicKey, state string) *UpdateInput {
+func NewUpdateInput(specificUid string, username string, password string, publicKey *model.PublicKey, state state.Type) *UpdateInput {
 	return &UpdateInput{
 		SpecificUid: specificUid,
 		Username:    username,
@@ -66,7 +65,7 @@ func UpdateCredentials(ctx context.Context, client http.Client, updateInput Upda
 		return nil, err
 	}
 
-	isWaitForUserToUpdateCreds := strings.EqualFold(updateInput.State, "WAIT_FOR_USER_TO_UPDATE_CREDS") || strings.EqualFold(updateInput.State, "$PRE_WAIT_FOR_USER_TO_UPDATE_CREDS")
+	isWaitForUserToUpdateCreds := updateInput.State == state.WAIT_FOR_USER_TO_UPDATE_CREDS || updateInput.State == state.PRE_WAIT_FOR_USER_TO_UPDATE_CREDS
 	req := client.NewPut(ctx, url, makeUpdateCredentialsReqBody(isWaitForUserToUpdateCreds, creds))
 
 	var outp UpdateOutput

--- a/client/device/asa/read.go
+++ b/client/device/asa/read.go
@@ -5,6 +5,7 @@ import (
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/device/tags"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/devicetype"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
@@ -28,7 +29,7 @@ type ReadOutput struct {
 	IgnoreCertificate   bool                 `json:"ignoreCertificate"`
 	ConnectivityState   int                  `json:"connectivityState,omitempty"`
 	ConnectivityError   string               `json:"connectivityError,omitempty"`
-	State               string               `json:"state"`
+	State               state.Type           `json:"state"`
 	Status              string               `json:"status"`
 	StateMachineDetails statemachine.Details `json:"stateMachineDetails"`
 }

--- a/client/device/asa/readspecific.go
+++ b/client/device/asa/readspecific.go
@@ -2,6 +2,7 @@ package asa
 
 import (
 	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
@@ -12,10 +13,10 @@ type ReadSpecificInput struct {
 }
 
 type ReadSpecificOutput struct {
-	SpecificUid string `json:"uid"`
-	State       string `json:"state"`
-	Namespace   string `json:"namespace"`
-	Type        string `json:"type"`
+	SpecificUid string     `json:"uid"`
+	State       state.Type `json:"state"`
+	Namespace   string     `json:"namespace"`
+	Type        string     `json:"type"`
 }
 
 func NewReadSpecificInput(uid string) *ReadSpecificInput {

--- a/client/device/asa/retry.go
+++ b/client/device/asa/retry.go
@@ -21,7 +21,7 @@ func UntilStateDoneAndConnectivityOk(ctx context.Context, client http.Client, ui
 
 		client.Logger.Printf("device state=%s\n", readOutp.State)
 
-		if strings.EqualFold(readOutp.State, state.DONE) && strings.EqualFold(readOutp.Status, "IDLE") {
+		if readOutp.State == state.DONE && strings.EqualFold(readOutp.Status, "IDLE") {
 
 			if readOutp.ConnectivityState <= 0 {
 				return false, fmt.Errorf("connectivity error: %s", readOutp.ConnectivityError)
@@ -29,10 +29,10 @@ func UntilStateDoneAndConnectivityOk(ctx context.Context, client http.Client, ui
 
 			return true, nil
 		}
-		if strings.EqualFold(readOutp.State, state.ERROR) {
+		if readOutp.State == state.ERROR {
 			return false, statemachine.NewWorkflowErrorFromDetails(readOutp.StateMachineDetails)
 		}
-		if strings.EqualFold(readOutp.State, state.BAD_CREDENTIALS) {
+		if readOutp.State == state.BAD_CREDENTIALS {
 			return false, statemachine.NewWorkflowErrorf("Bad Credentials")
 		}
 		return false, nil

--- a/client/device/cloudfmc/readspecific.go
+++ b/client/device/cloudfmc/readspecific.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 )
 
 type ReadSpecificInput struct {
@@ -11,10 +12,10 @@ type ReadSpecificInput struct {
 }
 
 type ReadSpecificOutput struct {
-	SpecificUid string `json:"uid"`
-	DomainUid   string `json:"domainUid"`
-	State       string `json:"state"`
-	Status      string `json:"status"`
+	SpecificUid string     `json:"uid"`
+	DomainUid   string     `json:"domainUid"`
+	State       state.Type `json:"state"`
+	Status      string     `json:"status"`
 }
 
 func NewReadSpecificInput(fmcId string) ReadSpecificInput {

--- a/client/device/cloudfmc/readspecific_outputbuilder.go
+++ b/client/device/cloudfmc/readspecific_outputbuilder.go
@@ -1,5 +1,7 @@
 package cloudfmc
 
+import "github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
+
 type ReadSpecificOutputBuilder struct {
 	readSpecificOutput *ReadSpecificOutput
 }
@@ -20,7 +22,7 @@ func (b *ReadSpecificOutputBuilder) DomainUid(domainUid string) *ReadSpecificOut
 	return b
 }
 
-func (b *ReadSpecificOutputBuilder) State(state string) *ReadSpecificOutputBuilder {
+func (b *ReadSpecificOutputBuilder) State(state state.Type) *ReadSpecificOutputBuilder {
 	b.readSpecificOutput.State = state
 	return b
 }

--- a/client/device/ios/iosconfig/read.go
+++ b/client/device/ios/iosconfig/read.go
@@ -3,6 +3,7 @@ package iosconfig
 import (
 	"context"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
@@ -14,7 +15,7 @@ type ReadInput struct {
 
 type ReadOutput struct {
 	Uid                 string               `json:"uid"`
-	State               string               `json:"state"`
+	State               state.Type           `json:"state"`
 	StateMachineDetails statemachine.Details `json:"stateMachineDetails"`
 }
 

--- a/client/device/ios/iosconfig/retry.go
+++ b/client/device/ios/iosconfig/retry.go
@@ -2,15 +2,13 @@ package iosconfig
 
 import (
 	"context"
-	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
-	"strings"
-
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 )
 
-func UntilState(ctx context.Context, client http.Client, specificUid string, expectedState string) retry.Func {
+func UntilState(ctx context.Context, client http.Client, specificUid string, expectedState state.Type) retry.Func {
 
 	// create ios config read request
 	readReq := NewReadRequest(ctx, client, *NewReadInput(
@@ -26,13 +24,13 @@ func UntilState(ctx context.Context, client http.Client, specificUid string, exp
 		}
 
 		client.Logger.Printf("ios config expectedState=%s\n", readOutp.State)
-		if strings.EqualFold(readOutp.State, expectedState) {
+		if readOutp.State == expectedState {
 			return true, nil
 		}
-		if strings.EqualFold(readOutp.State, state.ERROR) {
+		if readOutp.State == state.ERROR {
 			return false, statemachine.NewWorkflowErrorFromDetails(readOutp.StateMachineDetails)
 		}
-		if strings.EqualFold(readOutp.State, state.BAD_CREDENTIALS) {
+		if readOutp.State == state.BAD_CREDENTIALS {
 			return false, statemachine.NewWorkflowErrorf("Bad Credentials")
 		}
 		return false, nil

--- a/client/device/ios/readspecific.go
+++ b/client/device/ios/readspecific.go
@@ -2,6 +2,7 @@ package ios
 
 import (
 	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
@@ -12,10 +13,10 @@ type ReadSpecificInput struct {
 }
 
 type ReadSpecificOutput struct {
-	SpecificUid string `json:"uid"`
-	State       string `json:"state"`
-	Namespace   string `json:"namespace"`
-	Type        string `json:"type"`
+	SpecificUid string     `json:"uid"`
+	State       state.Type `json:"state"`
+	Namespace   string     `json:"namespace"`
+	Type        string     `json:"type"`
 }
 
 func NewReadSpecificInput(uid string) *ReadSpecificInput {

--- a/client/device/read_by_uid.go
+++ b/client/device/read_by_uid.go
@@ -3,6 +3,7 @@ package device
 import (
 	"context"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/device/tags"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
@@ -27,11 +28,11 @@ type ReadOutput struct {
 	Host            string          `json:"host"`
 	Tags            tags.Type       `json:"tags"`
 
-	IgnoreCertificate bool   `json:"ignoreCertificate"`
-	ConnectivityState int    `json:"connectivityState,omitempty"`
-	ConnectivityError string `json:"connectivityError,omitempty"`
-	State             string `json:"state"`
-	Status            string `json:"status"`
+	IgnoreCertificate bool       `json:"ignoreCertificate"`
+	ConnectivityState int        `json:"connectivityState,omitempty"`
+	ConnectivityError string     `json:"connectivityError,omitempty"`
+	State             state.Type `json:"state"`
+	Status            string     `json:"status"`
 }
 
 func NewReadByUidInput(uid string) *ReadByUidInput {

--- a/client/device/readspecific.go
+++ b/client/device/readspecific.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
@@ -12,10 +13,10 @@ type ReadSpecificInput struct {
 }
 
 type ReadSpecificOutput struct {
-	SpecificUid string `json:"uid"`
-	State       string `json:"state"`
-	Namespace   string `json:"namespace"`
-	Type        string `json:"type"`
+	SpecificUid string     `json:"uid"`
+	State       state.Type `json:"state"`
+	Namespace   string     `json:"namespace"`
+	Type        string     `json:"type"`
 }
 
 func NewReadSpecificInput(uid string) *ReadSpecificInput {

--- a/client/device/readspecific_outputbuilder.go
+++ b/client/device/readspecific_outputbuilder.go
@@ -1,5 +1,7 @@
 package device
 
+import "github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
+
 type ReadSpecificOutputBuilder struct {
 	readSpecificOutput *ReadSpecificOutput
 }
@@ -15,7 +17,7 @@ func (b *ReadSpecificOutputBuilder) SpecificUid(specificUid string) *ReadSpecifi
 	return b
 }
 
-func (b *ReadSpecificOutputBuilder) State(state string) *ReadSpecificOutputBuilder {
+func (b *ReadSpecificOutputBuilder) State(state state.Type) *ReadSpecificOutputBuilder {
 	b.readSpecificOutput.State = state
 	return b
 }

--- a/client/examples/create.go
+++ b/client/examples/create.go
@@ -9,12 +9,6 @@ type CreateInput struct {
 	Uid string
 }
 
-func NewCreateInput(uid string) CreateInput {
-	return CreateInput{
-		Uid: uid,
-	}
-}
-
 type CreateOutput struct {
 }
 

--- a/client/examples/create_outputbuilder.go
+++ b/client/examples/create_outputbuilder.go
@@ -1,0 +1,20 @@
+package examples
+
+type CreateInputBuilder struct {
+	createInput *CreateInput
+}
+
+func NewCreateInputBuilder() *CreateInputBuilder {
+	createInput := &CreateInput{}
+	b := &CreateInputBuilder{createInput: createInput}
+	return b
+}
+
+func (b *CreateInputBuilder) Uid(uid string) *CreateInputBuilder {
+	b.createInput.Uid = uid
+	return b
+}
+
+func (b *CreateInputBuilder) Build() CreateInput {
+	return *b.createInput
+}

--- a/client/examples/delete.go
+++ b/client/examples/delete.go
@@ -8,10 +8,6 @@ import (
 type DeleteInput struct {
 }
 
-func NewDeleteInput() DeleteInput {
-	return DeleteInput{}
-}
-
 type DeleteOutput struct {
 }
 

--- a/client/examples/read.go
+++ b/client/examples/read.go
@@ -8,10 +8,6 @@ import (
 type ReadInput struct {
 }
 
-func NewReadInput() ReadInput {
-	return ReadInput{}
-}
-
 type ReadOutput struct {
 }
 

--- a/client/internal/statemachine/retry.go
+++ b/client/internal/statemachine/retry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
 )
 
 // UntilStarted keeps polling until it finds the state machine with given identifier or error that is not a not found error
@@ -24,6 +25,37 @@ func UntilStarted(ctx context.Context, client http.Client, deviceUid string, sta
 			return true, nil
 		}
 		// other state machine is running, continue polling
+		return false, nil
+	}
+}
+
+func UntilDone(ctx context.Context, client http.Client, deviceUid string, stateMachineIdentifier string) retry.Func {
+	untilStartedRetryFunc := UntilStarted(ctx, client, deviceUid, stateMachineIdentifier)
+	started := false
+	return func() (bool, error) {
+		// first wait for state machine to begin
+		if !started {
+			ok, err := untilStartedRetryFunc()
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
+			}
+			started = true
+			return false, nil
+		}
+		// then we check if it is done
+		res, err := ReadInstanceByDeviceUid(ctx, client, NewReadInstanceByDeviceUidInput(deviceUid))
+		if err != nil {
+			return false, err
+		}
+		if res.StateMachineInstanceCondition == state.DONE {
+			return true, nil
+		} else if res.StateMachineInstanceCondition == state.ERROR {
+			return false, NewWorkflowErrorFromDetails(res.StateMachineDetails)
+		}
+		client.Logger.Printf("current state=%s\n", res.StateMachineInstanceCondition)
 		return false, nil
 	}
 }

--- a/client/internal/url/url.go
+++ b/client/internal/url/url.go
@@ -157,3 +157,15 @@ func CreateApplication(baseUrl string) string {
 func ReadApplication(baseUrl string) string {
 	return fmt.Sprintf("%s/aegis/rest/v1/services/targets/applications", baseUrl)
 }
+
+func CreateSec(baseUrl string) string {
+	return fmt.Sprintf("%s/aegis/rest/v1/services/targets/estreamers", baseUrl)
+}
+
+func ReadSec(baseUrl string, secUid string) string {
+	return fmt.Sprintf("%s/aegis/rest/v1/services/targets/estreamers/%s", baseUrl, secUid)
+}
+
+func DeleteSec(baseUrl string, secUid string) string {
+	return fmt.Sprintf("%s/aegis/rest/v1/services/targets/estreamers/%s", baseUrl, secUid)
+}

--- a/client/model/statemachine/instance.go
+++ b/client/model/statemachine/instance.go
@@ -1,5 +1,7 @@
 package statemachine
 
+import "github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine/state"
+
 // see also: https://github.com/cisco-lockhart/cdo-jvm-modules/blob/master/libs/lh-model/lh-model/src/main/java/com/cisco/lockhart/model/statemachine/model/StateMachineInstance.java
 type Instance struct {
 	Actions                       []Action          `json:"actions"`
@@ -13,7 +15,7 @@ type Instance struct {
 	ObjectReference               ObjectReference   `json:"objectReference"`
 	StateMachineDetails           Details           `json:"stateMachineDetails"`
 	StateMachineIdentifier        string            `json:"stateMachineIdentifier"`
-	StateMachineInstanceCondition string            `json:"stateMachineInstanceCondition"`
+	StateMachineInstanceCondition state.Type        `json:"stateMachineInstanceCondition"`
 	StateMachinePriority          string            `json:"stateMachinePriority"`
 	StateMachineType              string            `json:"stateMachineType"`
 	Status                        string            `json:"status"`
@@ -85,7 +87,7 @@ func (b *InstanceBuilder) StateMachineIdentifier(stateMachineIdentifier string) 
 	return b
 }
 
-func (b *InstanceBuilder) StateMachineInstanceCondition(stateMachineInstanceCondition string) *InstanceBuilder {
+func (b *InstanceBuilder) StateMachineInstanceCondition(stateMachineInstanceCondition state.Type) *InstanceBuilder {
 	b.instance.StateMachineInstanceCondition = stateMachineInstanceCondition
 	return b
 }

--- a/client/model/statemachine/state/state.go
+++ b/client/model/statemachine/state/state.go
@@ -1,11 +1,14 @@
 package state
 
+type Type string
+
 const (
-	DONE  = "DONE"
-	ERROR = "ERROR"
+	DONE  Type = "DONE"
+	ERROR Type = "ERROR"
 
 	// asa/ios device only
-	BAD_CREDENTIALS                   = "BAD_CREDENTIALS"
-	PRE_WAIT_FOR_USER_TO_UPDATE_CREDS = "$PRE_WAIT_FOR_USER_TO_UPDATE_CREDS"
-	PRE_READ_METADATA                 = "$PRE_READ_METADATA"
+	BAD_CREDENTIALS                   Type = "BAD_CREDENTIALS"
+	WAIT_FOR_USER_TO_UPDATE_CREDS     Type = "WAIT_FOR_USER_TO_UPDATE_CREDS"
+	PRE_WAIT_FOR_USER_TO_UPDATE_CREDS Type = "$PRE_WAIT_FOR_USER_TO_UPDATE_CREDS"
+	PRE_READ_METADATA                 Type = "$PRE_READ_METADATA"
 )

--- a/provider/internal/cdfmc/resource_test.go
+++ b/provider/internal/cdfmc/resource_test.go
@@ -20,7 +20,7 @@ resource "cdo_cdfmc" "test" {
 var resourceConfig = acctest.MustParseTemplate(resourceTemplate, resourceModel)
 
 func TestAccCdFmcResource(t *testing.T) {
-	t.Skip("we cant delete a fmc so this test cannot be run, or we should find a way to spin up new environment, either seems uneasy, skipping for now.")
+	t.Skip("we cant delete a fmc so this test cannot be run, or we should find a way to spin up new environment, neither seems uneasy, skipping for now.")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 acctest.PreCheckFunc(t),
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/provider/internal/cdfmc/resource_test.go
+++ b/provider/internal/cdfmc/resource_test.go
@@ -20,7 +20,7 @@ resource "cdo_cdfmc" "test" {
 var resourceConfig = acctest.MustParseTemplate(resourceTemplate, resourceModel)
 
 func TestAccCdFmcResource(t *testing.T) {
-	t.Skip("we cant delete a fmc so this test cannot be run, or we should find a way to spin up new environment, neither seems uneasy, skipping for now.")
+	t.Skip("we cant delete a fmc so this test cannot be run, or we should find a way to spin up new environment, either seems uneasy, skipping for now.")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 acctest.PreCheckFunc(t),
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/provider/internal/connector/sec/operation.go
+++ b/provider/internal/connector/sec/operation.go
@@ -1,0 +1,70 @@
+package sec
+
+import (
+	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/connector/sec"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func Read(ctx context.Context, resource *Resource, stateData *ResourceModel) error {
+
+	// do read
+	// e.g. readOutp, err := resource.client.ReadExample(ctx, ...)
+	readOutp, err := resource.client.ReadSec(ctx, sec.NewReadInputBuilder().Uid(stateData.Id.ValueString()).Build())
+	if err != nil {
+		return err
+	}
+
+	// map response to terraform types
+	// e.g. stateData.ID = types.StringValue(readOutp.Uid)
+	stateData.Id = types.StringValue(readOutp.Uid)
+	stateData.SecBootstrapData = types.StringValue(readOutp.BootStrapData)
+	stateData.Name = types.StringValue(readOutp.Name)
+
+	return nil
+}
+
+func Create(ctx context.Context, resource *Resource, planData *ResourceModel) error {
+
+	// do create
+	// e.g. createOutp, err := resource.client.CreateExample(ctx, ...)
+	createOutp, err := resource.client.CreateSec(ctx, sec.NewCreateInputBuilder().Build())
+	if err != nil {
+		return err
+	}
+
+	// map response to terraform types
+	// e.g. planData.ID = types.StringValue(createOutp.Uid)
+	planData.Id = types.StringValue(createOutp.Uid)
+	planData.SecBootstrapData = types.StringValue(createOutp.SecBootstrapData)
+	planData.CdoBootstrapData = types.StringValue(createOutp.CdoBoostrapData)
+	planData.Name = types.StringValue(createOutp.Name)
+
+	return nil
+}
+
+func Update(ctx context.Context, resource *Resource, planData *ResourceModel, stateData *ResourceModel) error {
+
+	// do update
+	// e.g. updateOutp, err := resource.client.UpdateExample(ctx, ...)
+	_, err := resource.client.UpdateSec(ctx, sec.NewUpdateInputBuilder().Build())
+	if err != nil {
+		return err
+	}
+	// map response to terraform types
+	// stateData.ID = types.StringValue(updateOutp.Uid)
+
+	return nil
+}
+
+func Delete(ctx context.Context, resource *Resource, stateData *ResourceModel) error {
+
+	// do delete
+	// _, err := resource.client.DeleteExample(ctx, ...)
+	_, err := resource.client.DeleteSec(ctx, sec.NewDeleteInputBuilder().Uid(stateData.Id.ValueString()).Build())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/provider/internal/connector/sec/operation.go
+++ b/provider/internal/connector/sec/operation.go
@@ -9,14 +9,12 @@ import (
 func Read(ctx context.Context, resource *Resource, stateData *ResourceModel) error {
 
 	// do read
-	// e.g. readOutp, err := resource.client.ReadExample(ctx, ...)
 	readOutp, err := resource.client.ReadSec(ctx, sec.NewReadInputBuilder().Uid(stateData.Id.ValueString()).Build())
 	if err != nil {
 		return err
 	}
 
 	// map response to terraform types
-	// e.g. stateData.ID = types.StringValue(readOutp.Uid)
 	stateData.Id = types.StringValue(readOutp.Uid)
 	stateData.SecBootstrapData = types.StringValue(readOutp.BootStrapData)
 	stateData.Name = types.StringValue(readOutp.Name)
@@ -27,14 +25,12 @@ func Read(ctx context.Context, resource *Resource, stateData *ResourceModel) err
 func Create(ctx context.Context, resource *Resource, planData *ResourceModel) error {
 
 	// do create
-	// e.g. createOutp, err := resource.client.CreateExample(ctx, ...)
 	createOutp, err := resource.client.CreateSec(ctx, sec.NewCreateInputBuilder().Build())
 	if err != nil {
 		return err
 	}
 
 	// map response to terraform types
-	// e.g. planData.ID = types.StringValue(createOutp.Uid)
 	planData.Id = types.StringValue(createOutp.Uid)
 	planData.SecBootstrapData = types.StringValue(createOutp.SecBootstrapData)
 	planData.CdoBootstrapData = types.StringValue(createOutp.CdoBoostrapData)
@@ -46,13 +42,10 @@ func Create(ctx context.Context, resource *Resource, planData *ResourceModel) er
 func Update(ctx context.Context, resource *Resource, planData *ResourceModel, stateData *ResourceModel) error {
 
 	// do update
-	// e.g. updateOutp, err := resource.client.UpdateExample(ctx, ...)
 	_, err := resource.client.UpdateSec(ctx, sec.NewUpdateInputBuilder().Build())
 	if err != nil {
 		return err
 	}
-	// map response to terraform types
-	// stateData.ID = types.StringValue(updateOutp.Uid)
 
 	return nil
 }
@@ -60,7 +53,6 @@ func Update(ctx context.Context, resource *Resource, planData *ResourceModel, st
 func Delete(ctx context.Context, resource *Resource, stateData *ResourceModel) error {
 
 	// do delete
-	// _, err := resource.client.DeleteExample(ctx, ...)
 	_, err := resource.client.DeleteSec(ctx, sec.NewDeleteInputBuilder().Uid(stateData.Id.ValueString()).Build())
 	if err != nil {
 		return err

--- a/provider/internal/connector/sec/resource.go
+++ b/provider/internal/connector/sec/resource.go
@@ -1,0 +1,177 @@
+package sec
+
+import (
+	"context"
+	"fmt"
+	cdoClient "github.com/CiscoDevnet/terraform-provider-cdo/go-client"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &Resource{}
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+type Resource struct {
+	client *cdoClient.Client
+}
+
+type ResourceModel struct {
+	Id               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	CdoBootstrapData types.String `tfsdk:"cdo_bootstrap_data"`
+	SecBootstrapData types.String `tfsdk:"sec_bootstrap_data"`
+}
+
+func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_sec"
+}
+
+func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "TODO",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "TODO",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "TODO",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"cdo_bootstrap_data": schema.StringAttribute{
+				MarkdownDescription: "TODO",
+				Computed:            true,
+				Sensitive:           true, // bootstrap data contains user api token
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"sec_bootstrap_data": schema.StringAttribute{
+				MarkdownDescription: "TODO",
+				Computed:            true,
+				Sensitive:           true, // bootstrap data contains user api token
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cdoClient.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *cdoClient.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+
+	tflog.Trace(ctx, "read SEC resource")
+
+	// 1. read state data
+	var stateData ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// 2. do read
+	if err := Read(ctx, r, &stateData); err != nil {
+		resp.Diagnostics.AddError("failed to read SEC resource", err.Error())
+	}
+
+	// 3. save data into terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, res *resource.CreateResponse) {
+
+	tflog.Trace(ctx, "create Sec resource")
+
+	// 1. read plan data into planData
+	var planData ResourceModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	// 2. use plan data to create device and fill up rest of the model
+	if err := Create(ctx, r, &planData); err != nil {
+		res.Diagnostics.AddError("failed to create Sec resource", err.Error())
+		return
+	}
+
+	// 3. set state using filled model
+	res.Diagnostics.Append(res.State.Set(ctx, &planData)...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, res *resource.UpdateResponse) {
+
+	tflog.Trace(ctx, "update Sec resource")
+
+	// 1. read plan data
+	var planData ResourceModel
+	res.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	// 2. read state data
+	var stateData ResourceModel
+	res.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	// 3. do update
+	if err := Update(ctx, r, &planData, &stateData); err != nil {
+		res.Diagnostics.AddError("failed to update Sec resource", err.Error())
+	}
+
+	// 4. set resulting state
+	res.Diagnostics.Append(res.State.Set(ctx, &stateData)...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, res *resource.DeleteResponse) {
+
+	tflog.Trace(ctx, "delete Sec resource")
+
+	var stateData ResourceModel
+	res.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	if err := Delete(ctx, r, &stateData); err != nil {
+		res.Diagnostics.AddError("failed to delete Sec resource", err.Error())
+	}
+}

--- a/provider/internal/connector/sec/resource.go
+++ b/provider/internal/connector/sec/resource.go
@@ -36,25 +36,25 @@ func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, r
 func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "TODO",
+		MarkdownDescription: "Provides an SEC connector resource. This allows SEC to be onboarded, updated, and deleted on CDO.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "TODO",
+				MarkdownDescription: "Unique identifier of the device. This is a UUID and is automatically generated when the device is created.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "TODO",
+				MarkdownDescription: "A generated name for the Secure Event Connector (SEC). This name is unique.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"cdo_bootstrap_data": schema.StringAttribute{
-				MarkdownDescription: "TODO",
+				MarkdownDescription: "CDO bootstrap data.",
 				Computed:            true,
 				Sensitive:           true, // bootstrap data contains user api token
 				PlanModifiers: []planmodifier.String{
@@ -62,7 +62,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				},
 			},
 			"sec_bootstrap_data": schema.StringAttribute{
-				MarkdownDescription: "TODO",
+				MarkdownDescription: "SEC bootstrap data.",
 				Computed:            true,
 				Sensitive:           true, // bootstrap data contains user api token
 				PlanModifiers: []planmodifier.String{

--- a/provider/internal/connector/sec/resource_test.go
+++ b/provider/internal/connector/sec/resource_test.go
@@ -1,0 +1,52 @@
+package sec_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/CiscoDevnet/terraform-provider-cdo/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+var resourceModel = struct{}{}
+
+const resourceTemplate = `
+resource "cdo_sec" "test" {
+}`
+
+var resourceConfig = acctest.MustParseTemplate(resourceTemplate, resourceModel)
+
+func TestAccSecResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 acctest.PreCheckFunc(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: acctest.ProviderConfig() + resourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith("cdo_sec.test", "name", func(value string) error {
+						if !strings.ContainsAny(value, "SEC") {
+							return fmt.Errorf("SEC name does not contain \"SEC\" after apply, this is likely an error")
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("cdo_sec.test", "cdo_bootstrap_data", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("CDO bootstrap data is empty after apply")
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("cdo_sec.test", "sec_bootstrap_data", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("SEC bootstrap data is empty after apply")
+						}
+						return nil
+					}),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/provider/internal/examples/data_source.go
+++ b/provider/internal/examples/data_source.go
@@ -34,7 +34,7 @@ type ExampleDataSourceModel struct {
 
 // Metadata is primarily used to define the name for this data source.
 func (d *ExampleDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_ios_device"
+	resp.TypeName = req.ProviderTypeName + "_example"
 }
 
 // Schema is primarily used to define the terraform schema for this data source.

--- a/provider/internal/provider/provider.go
+++ b/provider/internal/provider/provider.go
@@ -6,7 +6,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/CiscoDevnet/terraform-provider-cdo/internal/connector"
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/connector/connectoronboarding"
+	"github.com/CiscoDevnet/terraform-provider-cdo/internal/connector/sec"
 	"os"
 
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/cdfmc"
@@ -15,7 +17,6 @@ import (
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/device/ftd"
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/tenant"
 
-	"github.com/CiscoDevnet/terraform-provider-cdo/internal/connector"
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/user"
 	"github.com/CiscoDevnet/terraform-provider-cdo/internal/user_api_token"
 
@@ -163,6 +164,7 @@ func (p *CdoProvider) Resources(ctx context.Context) []func() resource.Resource 
 		ftdonboarding.NewResource,
 		connectoronboarding.NewResource,
 		cdfmc.NewResource,
+		sec.NewResource,
 	}
 }
 


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-72231

### Description
- Read SEC
- Update SEC (empty implementation)
- Delete SEC
- Create SEC
	- Create the SEC device in CDO and generate the CDO bootstrap data and SEC bootstrap data. This is only part of the onboarding process.
- Refactored state machine's state field from `string` to concrete `state.Type`