### PR TITLE
fix(LH-72736): delete connector occasionally fails

### DIFF
--- a/client/connector/create.go
+++ b/client/connector/create.go
@@ -64,7 +64,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 			Logger(client.Logger).
 			Delay(2*time.Second).
 			EarlyExitOnError(true).
-			Timeout(time.Minute). // typically a few seconds should be enough
+			Timeout(3*time.Minute). // typically a few seconds should be enough, but it can go over 1 minute
 			Build(),
 	)
 	if err != nil {

--- a/client/connector/delete.go
+++ b/client/connector/delete.go
@@ -2,9 +2,11 @@ package connector
 
 import (
 	"context"
-
+	"errors"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
+	"time"
 )
 
 type DeleteInput struct {
@@ -22,14 +24,58 @@ type DeleteOutput struct {
 
 func Delete(ctx context.Context, client http.Client, inp DeleteInput) (*DeleteOutput, error) {
 
-	url := url.DeleteConnector(client.BaseUrl(), inp.Uid)
-
-	req := client.NewDelete(ctx, url)
-
 	var deleteOutp DeleteOutput
-	if err := req.Send(&deleteOutp); err != nil {
-		return &DeleteOutput{}, err
+
+	// retry delete until connector is not present
+	// we cant just delete normally because sometimes it can fail to delete for some unknown reason in CI
+	err := retry.Do(
+		ctx,
+		func() (bool, error) {
+			if connectorPresent(ctx, client, inp.Uid) {
+				err := sendDeleteConnectorRequest(ctx, client, inp.Uid, &deleteOutp)
+				if errors.Is(err, http.NotFoundError) {
+					return false, nil // delete in progress, ignore not found error
+				}
+				return false, err // return other error, if any
+			} else {
+				return true, nil // connector no longer present, delete works just fine
+			}
+		},
+		retry.NewOptionsBuilder().
+			Retries(-1).
+			Message("Waiting for connector to be deleted...").
+			Logger(client.Logger).
+			Timeout(3*time.Minute).
+			EarlyExitOnError(true).
+			Delay(500*time.Millisecond).
+			Build(),
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return &deleteOutp, nil
+}
+
+func connectorPresent(ctx context.Context, client http.Client, uid string) bool {
+	connectors, err := ReadAll(ctx, client, *NewReadAllInput())
+	if err != nil {
+		return false
+	}
+	present := false
+	for _, outp := range *connectors {
+		if outp.Uid == uid {
+			present = true
+		}
+	}
+	return present
+}
+
+func sendDeleteConnectorRequest(ctx context.Context, client http.Client, uid string, deleteOutp *DeleteOutput) error {
+	deleteUrl := url.DeleteConnector(client.BaseUrl(), uid)
+	deleteReq := client.NewDelete(ctx, deleteUrl)
+	if err := deleteReq.Send(&deleteOutp); err != nil {
+		return err
+	}
+	return nil
 }

--- a/client/connector/delete_test.go
+++ b/client/connector/delete_test.go
@@ -2,10 +2,11 @@ package connector_test
 
 import (
 	"context"
-	"fmt"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/connector"
-	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	internalHttp "github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
 	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 	"time"
 
@@ -17,6 +18,15 @@ func TestDelete(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	validDeleteOutput := connector.DeleteOutput{}
+	validConnector := connector.NewConnectorOutputBuilder().
+		WithUid(connectorUid).
+		WithTenantUid(tenantUid).
+		WithName(connectorName).
+		Build()
+	connectorPresentResponse := httpmock.NewJsonResponderOrPanic(200, []connector.ReadOutput{validConnector})
+	connectorMissingResponse := httpmock.NewJsonResponderOrPanic(200, []connector.ReadOutput{})
+	connectorDeleteInitiatedResponse := httpmock.NewJsonResponderOrPanic(200, validDeleteOutput)
+	errorMessage := "intentional failed to delete error"
 
 	testCases := []struct {
 		testName   string
@@ -26,13 +36,18 @@ func TestDelete(t *testing.T) {
 	}{
 		{
 			testName: "successfully delete SDC",
-			sdcUid:   connectorUid,
+			sdcUid:   validConnector.Uid,
 
 			setupFunc: func() {
 				httpmock.RegisterResponder(
-					"DELETE",
-					fmt.Sprintf("/aegis/rest/v1/services/targets/proxies/%s", connectorUid),
-					httpmock.NewJsonResponderOrPanic(200, validDeleteOutput),
+					http.MethodGet,
+					url.ReadAllConnectors(baseUrl),
+					connectorPresentResponse.Then(connectorMissingResponse),
+				)
+				httpmock.RegisterResponder(
+					http.MethodDelete,
+					url.DeleteConnector(baseUrl, validConnector.Uid),
+					connectorDeleteInitiatedResponse,
 				)
 			},
 
@@ -44,19 +59,25 @@ func TestDelete(t *testing.T) {
 		},
 		{
 			testName: "should error if failed to delete",
-			sdcUid:   connectorUid,
+			sdcUid:   validConnector.Uid,
 
 			setupFunc: func() {
 				httpmock.RegisterResponder(
-					"DELETE",
-					fmt.Sprintf("/aegis/rest/v1/services/targets/proxies/%s", connectorUid),
-					httpmock.NewJsonResponderOrPanic(500, nil),
+					http.MethodGet,
+					url.ReadAllConnectors(baseUrl),
+					connectorPresentResponse.Then(connectorMissingResponse),
+				)
+				httpmock.RegisterResponder(
+					http.MethodDelete,
+					url.DeleteConnector(baseUrl, validConnector.Uid),
+					httpmock.NewJsonResponderOrPanic(500, errorMessage),
 				)
 			},
 
 			assertFunc: func(output *connector.DeleteOutput, err error, t *testing.T) {
 				assert.NotNil(t, err, "error should be nil")
-				assert.Equal(t, &connector.DeleteOutput{}, output, "output should be zero value")
+				assert.ErrorContains(t, err, errorMessage)
+				assert.Nil(t, output)
 			},
 		},
 	}
@@ -69,7 +90,7 @@ func TestDelete(t *testing.T) {
 
 			output, err := connector.Delete(
 				context.Background(),
-				*http.MustNewWithConfig(baseUrl, "a_valid_token", 0, 0, time.Minute),
+				*internalHttp.MustNewWithConfig(baseUrl, "a_valid_token", 0, 0, time.Minute),
 				connector.NewDeleteInput(testCase.sdcUid),
 			)
 

--- a/client/internal/http/error.go
+++ b/client/internal/http/error.go
@@ -1,0 +1,44 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ErrorType is the base type for http error
+type ErrorType interface {
+	Error() string
+}
+
+type errorType struct{}
+
+func (errorType) Error() string {
+	return ""
+}
+
+// Error is a base error to facilitate `errors.Is(xxx, http.Error)`
+var Error = errorType{}
+
+// ClientError facilitate `errors.Is(xxx, http.ClientError)`
+var ClientError = fmt.Errorf("%w", Error)
+
+// ServerError facilitate `errors.Is(xxx, http.ServerError)`
+var ServerError = fmt.Errorf("%w", Error)
+
+var NotFoundError = fmt.Errorf("%w%s", ClientError, http.StatusText(http.StatusNotFound))
+
+// errorFromStatusCode returns an error of the corresponding status code that we maybe interested in checking later using `errors.Is(err, http.XXXError)`
+func errorFromStatusCode(code int) ErrorType {
+	// TODO: use go generate to create errors for all http status and return them here, for now we just manually create them where needed
+	switch true {
+	case code == http.StatusNotFound:
+		return NotFoundError
+
+	case code > http.StatusInternalServerError:
+		return ServerError
+	case code > http.StatusBadRequest:
+		return ClientError
+	default:
+		return nil
+	}
+}

--- a/client/internal/http/request.go
+++ b/client/internal/http/request.go
@@ -106,7 +106,15 @@ func (r *Request) send(output any) error {
 	// check status
 	if res.StatusCode >= 400 {
 		body, err := io.ReadAll(res.Body)
-		err = fmt.Errorf("failed: url=%s, code=%d, status=%s, body=%s, readBodyErr=%s, method=%s, header=%s", r.url, res.StatusCode, res.Status, string(body), err, r.method, r.Header)
+		errInfo := fmt.Sprintf("url=%s, code=%d, status=%s, body=%s, readBodyErr=%s, method=%s, header=%s", r.url, res.StatusCode, res.Status, string(body), err, r.method, r.Header)
+		interestedError := errorFromStatusCode(res.StatusCode)
+		if interestedError == nil {
+			err = fmt.Errorf("http error: %s", errInfo)
+		} else {
+			// we wrap the error here so that later we can check it with, e.g. `errors.Is(err, http.InterestedError)`
+			err = fmt.Errorf("http error: %w%s", interestedError, errInfo)
+		}
+
 		r.Error = err
 		return err
 	}


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-72736

### Description
The root cause is unclear as I cant reproduce it consistently. The temporary fix is to keep trying delete until the backend does not return that connector anymore for GET request. Not entirely sure if this will fix it.

Also added ability to check for status code error that we are interested in.