### PR TITLE
fix(LH-73329): Fix error when create virtual FTD with no performance tier 

### DIFF
--- a/provider/internal/device/ftd/configvalidator.go
+++ b/provider/internal/device/ftd/configvalidator.go
@@ -15,7 +15,7 @@ func (c performanceTierConfigValidator) Description(ctx context.Context) string 
 }
 
 func (c performanceTierConfigValidator) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("Ensure performance tier is set for virtual FTD.")
+	return fmt.Sprintln("Ensure performance tier is set for virtual FTD.")
 }
 
 func (c performanceTierConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/provider/internal/device/ftd/configvalidator.go
+++ b/provider/internal/device/ftd/configvalidator.go
@@ -28,7 +28,7 @@ func (c performanceTierConfigValidator) ValidateResource(ctx context.Context, re
 	// if configData virtual is set to true
 	if !configData.Virtual.IsUnknown() && !configData.Virtual.IsNull() && configData.Virtual.ValueBool() {
 		// and performance tier is not set
-		if configData.PerformanceTier.IsNull() || configData.PerformanceTier.IsNull() {
+		if configData.PerformanceTier.IsNull() || configData.PerformanceTier.IsUnknown() {
 			// then we error
 			resp.Diagnostics.AddError("Performance Tier is required for virtual FTD.", "You need to select a performance tiers for virtual FTD. Allowed values are: [\"FTDv5\", \"FTDv10\", \"FTDv20\", \"FTDv30\", \"FTDv50\", \"FTDv100\", \"FTDv\"].")
 		}

--- a/provider/internal/device/ftd/configvalidator.go
+++ b/provider/internal/device/ftd/configvalidator.go
@@ -1,0 +1,36 @@
+package ftd
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var _ resource.ConfigValidator = &performanceTierConfigValidator{}
+
+type performanceTierConfigValidator struct{}
+
+func (c performanceTierConfigValidator) Description(ctx context.Context) string {
+	return c.MarkdownDescription(ctx)
+}
+
+func (c performanceTierConfigValidator) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("Ensure performance tier is set for virtual FTD.")
+}
+
+func (c performanceTierConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configData ResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// if configData virtual is set to true
+	if !configData.Virtual.IsUnknown() && !configData.Virtual.IsNull() && configData.Virtual.ValueBool() {
+		// and performance tier is not set
+		if configData.PerformanceTier.IsNull() || configData.PerformanceTier.IsNull() {
+			// then we error
+			resp.Diagnostics.AddError("Performance Tier is required for virtual FTD.", "You need to select a performance tiers for virtual FTD. Allowed values are: [\"FTDv5\", \"FTDv10\", \"FTDv20\", \"FTDv30\", \"FTDv50\", \"FTDv100\", \"FTDv\"].")
+		}
+	}
+}

--- a/provider/internal/device/ftd/configvalidator.go
+++ b/provider/internal/device/ftd/configvalidator.go
@@ -30,7 +30,10 @@ func (c performanceTierConfigValidator) ValidateResource(ctx context.Context, re
 		// and performance tier is not set
 		if configData.PerformanceTier.IsNull() || configData.PerformanceTier.IsUnknown() {
 			// then we error
-			resp.Diagnostics.AddError("Performance Tier is required for virtual FTD.", "You need to select a performance tiers for virtual FTD. Allowed values are: [\"FTDv5\", \"FTDv10\", \"FTDv20\", \"FTDv30\", \"FTDv50\", \"FTDv100\", \"FTDv\"].")
+			resp.Diagnostics.AddError(
+				"Performance Tier must be specified for FTDvs",
+				"Please select a performance tier. Allowed values are: [\"FTDv5\", \"FTDv10\", \"FTDv20\", \"FTDv30\", \"FTDv50\", \"FTDv100\", \"FTDv\"].",
+			)
 		}
 	}
 }

--- a/provider/internal/device/ftd/resource.go
+++ b/provider/internal/device/ftd/resource.go
@@ -35,41 +35,6 @@ type Resource struct {
 	client *cdoClient.Client
 }
 
-var _ resource.ConfigValidator = &performanceTierConfigValidator{}
-
-type performanceTierConfigValidator struct{}
-
-func (c performanceTierConfigValidator) Description(ctx context.Context) string {
-	return c.MarkdownDescription(ctx)
-}
-
-func (c performanceTierConfigValidator) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("TODO")
-}
-
-func (c performanceTierConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configData ResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// if configData virtual is set to true
-	if !configData.Virtual.IsUnknown() && !configData.Virtual.IsNull() && configData.Virtual.ValueBool() {
-		// and performance tier is not set
-		if configData.PerformanceTier.IsNull() || configData.PerformanceTier.IsNull() {
-			// then we error
-			resp.Diagnostics.AddError("Performance Tier is required for virtual FTD.", "You need to select a performance tiers for virtual FTD. Allowed values are: [\"FTDv5\", \"FTDv10\", \"FTDv20\", \"FTDv30\", \"FTDv50\", \"FTDv100\", \"FTDv\"].")
-		}
-	}
-}
-
-func (r *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
-	return []resource.ConfigValidator{
-		performanceTierConfigValidator{},
-	}
-}
-
 type ResourceModel struct {
 	ID               types.String `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
@@ -298,4 +263,10 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, res *
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, res *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, res)
+}
+
+func (r *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		performanceTierConfigValidator{},
+	}
 }

--- a/provider/internal/device/ftd/resource.go
+++ b/provider/internal/device/ftd/resource.go
@@ -25,6 +25,7 @@ import (
 
 var _ resource.Resource = &Resource{}
 var _ resource.ResourceWithImportState = &Resource{}
+var _ resource.ResourceWithConfigValidators = &Resource{}
 
 func NewResource() resource.Resource {
 	return &Resource{}
@@ -32,6 +33,41 @@ func NewResource() resource.Resource {
 
 type Resource struct {
 	client *cdoClient.Client
+}
+
+var _ resource.ConfigValidator = &performanceTierConfigValidator{}
+
+type performanceTierConfigValidator struct{}
+
+func (c performanceTierConfigValidator) Description(ctx context.Context) string {
+	return c.MarkdownDescription(ctx)
+}
+
+func (c performanceTierConfigValidator) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("TODO")
+}
+
+func (c performanceTierConfigValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configData ResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// if configData virtual is set to true
+	if !configData.Virtual.IsUnknown() && !configData.Virtual.IsNull() && configData.Virtual.ValueBool() {
+		// and performance tier is not set
+		if configData.PerformanceTier.IsNull() || configData.PerformanceTier.IsNull() {
+			// then we error
+			resp.Diagnostics.AddError("Performance Tier is required for virtual FTD.", "You need to select a performance tiers for virtual FTD. Allowed values are: [\"FTDv5\", \"FTDv10\", \"FTDv20\", \"FTDv30\", \"FTDv50\", \"FTDv100\", \"FTDv\"].")
+		}
+	}
+}
+
+func (r *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		performanceTierConfigValidator{},
+	}
 }
 
 type ResourceModel struct {


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-73329

### Description
**Given following FTD configuration** (`virtual` is true, but `performance_tier` is missing)
```
resource "cdo_ftd_device" "ftd" { 
	name = "my-ftd" 
	access_policy_name = "Default Access Control Policy"
	virtual = true 
	licenses = ["BASE"] 
}
```
#### Before

<img width="1320" alt="Screenshot 2023-11-28 at 10 29 06" src="https://github.com/CiscoDevNet/terraform-provider-cdo/assets/39546701/3867b4b2-1866-4fb0-be24-fa1548c1ba9a">

#### After

<img width="1346" alt="Screenshot 2023-11-28 at 10 30 10" src="https://github.com/CiscoDevNet/terraform-provider-cdo/assets/39546701/0ba04887-5eec-4af8-8185-8172f6277c93">
