### PR TITLE
fix(LH-73399): Correctly handle FTD deletion

### DIFF
--- a/client/connector/read.go
+++ b/client/connector/read.go
@@ -86,7 +86,7 @@ func ReadByName(ctx context.Context, client http.Client, readInp ReadByNameInput
 	}
 
 	if len(arrayOutp) == 0 {
-		return nil, fmt.Errorf("no connector found")
+		return nil, fmt.Errorf("%w: no connector found", http.NotFoundError)
 	}
 
 	if len(arrayOutp) > 1 {

--- a/client/device/cloudfmc/read.go
+++ b/client/device/cloudfmc/read.go
@@ -32,7 +32,7 @@ func Read(ctx context.Context, client http.Client, readInp ReadInput) (*ReadOutp
 	}
 
 	if len(cloudFmcDevices) == 0 {
-		return nil, fmt.Errorf("firewall management center (FMC) not found")
+		return nil, fmt.Errorf("%w: firewall management center (FMC) not found", http.NotFoundError)
 	}
 
 	if len(cloudFmcDevices) > 1 {

--- a/client/device/cloudftd/create.go
+++ b/client/device/cloudftd/create.go
@@ -80,7 +80,7 @@ func Create(ctx context.Context, client http.Client, createInp CreateInput) (*Cr
 		return nil, err
 	}
 	if len(readFmcDomainRes.Items) == 0 {
-		return nil, fmt.Errorf("fmc domain info not found")
+		return nil, fmt.Errorf("%w: fmc domain info not found", http.NotFoundError)
 	}
 
 	// 3. get access policies using Cloud FMC domain uid

--- a/client/device/cloudftd/delete.go
+++ b/client/device/cloudftd/delete.go
@@ -84,9 +84,7 @@ func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*De
 		if strings.Contains(deviceRecord.Model, "Firepower Threat Defense") { // Question: is there a better way to check? Does this check cover all cases?
 			// found
 			ftdRecordId = record.Id
-		} else {
-			// not a FTD, just some other device with the same name, ignore
-		}
+		} // else not a FTD, just some other device with the same name, ignore
 	}
 
 	if ftdRecordId != "" {
@@ -123,10 +121,9 @@ func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*De
 			return nil, err
 		}
 
-	} else {
-		// the ftd device record is not found in cdFMC if reach here, this is unexpected,
-		// but since we are performing delete operation, it is going to be deleted anyway, so ignore it
-	}
+	} // else
+	// the ftd device record is not found in cdFMC if reach here, this is unexpected,
+	// but since we are performing delete operation, it is going to be deleted anyway, so ignore it
 
 	// now we checked the FTD is ready to be deleted
 

--- a/client/device/cloudftd/delete.go
+++ b/client/device/cloudftd/delete.go
@@ -2,11 +2,18 @@ package cloudftd
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudfmc"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudfmc/fmcappliance"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudfmc/fmcconfig"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudfmc/fmcplatform"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/retry"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
+	"strings"
+	"time"
 )
 
 type DeleteInput struct {
@@ -19,8 +26,7 @@ func NewDeleteInput(uid string) DeleteInput {
 	}
 }
 
-type DeleteOutput struct {
-}
+type DeleteOutput = device.DeleteOutput
 
 func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*DeleteOutput, error) {
 
@@ -36,7 +42,99 @@ func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*De
 		return nil, err
 	}
 
-	// 3. schedule a state machine for cloud fmc to delete the cloud FTD
+	// 2.5 wait for any FTD deployment to finish, otherwise backend fmceDeleteFtdcStateMachine will fail
+	// in order to check for FTD deployment status, we need to read FMC host and domainUid
+	// 2.5.1 read fmc, host is in the response
+	fmcRes, err := cloudfmc.Read(ctx, client, cloudfmc.NewReadInput())
+	if err != nil {
+		return nil, err
+	}
+	// 2.5.2 read fmc domain info in its specific/appliance device, fmcDomainUid is in the domain info
+	readFmcDomainRes, err := fmcplatform.ReadFmcDomainInfo(ctx, client, fmcplatform.NewReadDomainInfoInput(fmcRes.Host))
+	if err != nil {
+		return nil, err
+	}
+	if len(readFmcDomainRes.Items) == 0 {
+		return nil, fmt.Errorf("%w: failed to read fmc domain uid, fmc domain info not found", http.NotFoundError)
+	}
+	fmcDomainUid := readFmcDomainRes.Items[0].Uuid
+
+	// now we find the FTD device record, to do that we need to find all device records
+	// then we find the FTD device record with the same name as the CDO FTD
+	// 2.5.1 read FTD name from input uid
+	readFtdOutp, err := ReadByUid(ctx, client, NewReadByUidInput(deleteInp.Uid))
+	if err != nil {
+		return nil, err
+	}
+	// 2.5.2 read all device records
+	allDeviceRecords, err := fmcconfig.ReadAllDeviceRecords(ctx, client, fmcconfig.NewReadAllDeviceRecordsInput(fmcDomainUid, fmcRes.Host))
+	if err != nil {
+		return nil, err
+	}
+	var ftdRecordId string
+	// 2.5.3 check if FTD name is present in device records, logic: same name + both are FTDs = found
+	client.Logger.Printf("checking if FTD already exists with id=%s and name=%s\n", deleteInp.Uid, fmcRes.Name)
+	for _, record := range allDeviceRecords.Items {
+		if record.Name != readFtdOutp.Name {
+			// different name, ignore
+			continue
+		}
+		// the allDeviceRecords only contains the name, so we need to make another call to retrieve the details of the device to check whether this is a FTD
+		// potentially we will be making a lot of network calls and cause this loop to run for long time if
+		// we have many device records with the same name, I suppose that rarely happens
+		deviceRecord, err := fmcconfig.ReadDeviceRecord(ctx, client, fmcconfig.NewReadDeviceRecordInput(fmcDomainUid, fmcRes.Host, record.Id))
+		if err != nil {
+			return nil, err
+		}
+		if strings.Contains(deviceRecord.Model, "Firepower Threat Defense") { // Question: is there a better way to check? Does this check cover all cases?
+			// found
+			ftdRecordId = record.Id
+		} else {
+			// not a FTD, just some other device with the same name, ignore
+		}
+	}
+
+	if ftdRecordId != "" {
+		// FTD record found in the cdFMC device records
+		// now use the FTD device record id and to read the device record, until the FTD deployment status is DEPLOYED
+
+		// 2.5.4 re-read FMC's FTD deployment status until it is DEPLOYED
+		err = retry.Do(
+			ctx,
+			func() (bool, error) {
+				ftdDeviceRecord, err := fmcconfig.ReadDeviceRecord(ctx, client, fmcconfig.NewReadDeviceRecordInput(fmcDomainUid, fmcRes.Host, ftdRecordId))
+				if err != nil {
+					return false, err
+				}
+				if ftdDeviceRecord.DeploymentStatus == "DEPLOYED" { // no idea what this deployment status could be, so it is a string
+					return true, nil
+					// TODO: check for error here: like if ftdDeviceRecord.DeploymentStatus == "DEPLOY_ERROR" {, not sure what is the error deployment status so I did not do it for now
+				} else {
+					return false, nil
+				}
+			},
+			retry.NewOptionsBuilder().
+				Message("Waiting for FTD deployment to finish...").
+				Timeout(15*time.Minute). // usually 5-10 minutes
+				Delay(3*time.Second).
+				Logger(client.Logger).
+				Retries(-1).
+				EarlyExitOnError(true).
+				Build(),
+		)
+		if err != nil {
+			// error during retry, maybe the deployment failed, we fail the delete as well
+			return nil, err
+		}
+
+	} else {
+		// the ftd device record is not found in cdFMC if reach here, this is unexpected,
+		// but since we are performing delete operation, it is going to be deleted anyway, so ignore it
+	}
+
+	// now we checked the FTD is ready to be deleted
+
+	// 3. delete FTD in cdFMC, schedule a state machine for cloud fmc to delete the cloud FTD
 	_, err = fmcappliance.Update(
 		ctx,
 		client,
@@ -50,12 +148,12 @@ func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*De
 		return nil, err
 	}
 
-	// 4. wait until the delete cloud FTD state machine has started
-	err = retry.Do(
+	// 4. wait until the delete cloud FTD state machine is done
+	cdFmcFtdDeleteErr := retry.Do(
 		ctx,
-		statemachine.UntilStarted(ctx, client, fmcReadSpecificRes.SpecificUid, "fmceDeleteFtdcStateMachine"),
+		statemachine.UntilDone(ctx, client, fmcReadSpecificRes.SpecificUid, "fmceDeleteFtdcStateMachine"),
 		retry.NewOptionsBuilder().
-			Message("Waiting for FTD deletion to begin...").
+			Message("Waiting for FTD deletion to finish...").
 			Retries(retry.DefaultRetries).
 			Delay(retry.DefaultDelay).
 			Logger(client.Logger).
@@ -63,13 +161,15 @@ func Delete(ctx context.Context, client http.Client, deleteInp DeleteInput) (*De
 			Timeout(retry.DefaultTimeout).
 			Build(),
 	)
-	if err != nil {
-		return nil, err
+
+	// 5. delete FTD in CDO as well, before checking any error from above, because it maybe because it is already deleted or something
+	ftdDeleteOutput, err := device.Delete(ctx, client, *device.NewDeleteInput(deleteInp.Uid))
+
+	if err != nil || cdFmcFtdDeleteErr != nil {
+		return nil, errors.Join(cdFmcFtdDeleteErr, err)
 	}
 
-	// 5. we are not waiting for it to finish, like the CDO UI
-
 	// done!
-	return &DeleteOutput{}, nil
+	return ftdDeleteOutput, nil
 
 }

--- a/client/device/cloudftd/delete_test.go
+++ b/client/device/cloudftd/delete_test.go
@@ -297,22 +297,6 @@ func readFtdIsSuccessful(success bool) {
 	}
 }
 
-//func readFmcDomainInfoIsSuccessful(success bool) {
-//	if success {
-//		httpmock.RegisterResponder(
-//			http.MethodGet,
-//			url.ReadFmcDomainInfo(fmcHost),
-//			httpmock.NewJsonResponderOrPanic(200, validReadFmcDomainInfoOutput),
-//		)
-//	} else {
-//		httpmock.RegisterResponder(
-//			http.MethodGet,
-//			url.ReadFmcDomainInfo(fmcHost),
-//			httpmock.NewJsonResponderOrPanic(500, "intentional error"),
-//		)
-//	}
-//}
-
 func waitForFtdDeleteStateMachineEndedSuccessful(success bool) {
 	if success {
 		httpmock.RegisterResponder(

--- a/client/device/cloudftd/delete_test.go
+++ b/client/device/cloudftd/delete_test.go
@@ -24,31 +24,18 @@ func TestDeleteCloudFtd(t *testing.T) {
 		assertFunc func(output *cloudftd.DeleteOutput, err error, t *testing.T)
 	}{
 		{
-			testName: "successfully create Cloud FTD",
+			testName: "successfully delete Cloud FTD, and waited for delete state machine",
 			input:    cloudftd.NewDeleteInput(ftdUid),
 			setupFunc: func() {
 				readFmcIsSuccessful(true)
 				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
 				triggerFtdDeleteOnFmcIsSuccessful(true)
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(true)
-			},
-			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
-				assert.Nil(t, err)
-				assert.NotNil(t, output)
-				assert.Equal(t, validDeleteOutput, *output)
-			},
-		},
-		{
-			testName: "successfully create Cloud FTD, and waited for delete state machine",
-			input:    cloudftd.NewDeleteInput(ftdUid),
-			setupFunc: func() {
-				readFmcIsSuccessful(true)
-				readFmcSpecificIsSuccessful(true)
-				triggerFtdDeleteOnFmcIsSuccessful(true)
-				waitForFtdDeleteStateMachineTriggeredReturnedNotFound()
-				waitForFtdDeleteStateMachineTriggeredReturnedNotFound()
-				waitForFtdDeleteStateMachineTriggeredReturnedNotFound()
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
 			},
 			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
 				assert.Nil(t, err)
@@ -62,8 +49,13 @@ func TestDeleteCloudFtd(t *testing.T) {
 			setupFunc: func() {
 				readFmcIsSuccessful(false)
 				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
 				triggerFtdDeleteOnFmcIsSuccessful(true)
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
 			},
 			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
 				assert.NotNil(t, err)
@@ -76,8 +68,13 @@ func TestDeleteCloudFtd(t *testing.T) {
 			setupFunc: func() {
 				readFmcIsSuccessful(true)
 				readFmcSpecificIsSuccessful(false)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
 				triggerFtdDeleteOnFmcIsSuccessful(true)
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
 			},
 			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
 				assert.NotNil(t, err)
@@ -90,8 +87,13 @@ func TestDeleteCloudFtd(t *testing.T) {
 			setupFunc: func() {
 				readFmcIsSuccessful(true)
 				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
 				triggerFtdDeleteOnFmcIsSuccessful(false)
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
 			},
 			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
 				assert.NotNil(t, err)
@@ -104,8 +106,13 @@ func TestDeleteCloudFtd(t *testing.T) {
 			setupFunc: func() {
 				readFmcIsSuccessful(true)
 				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
 				triggerFtdDeleteOnFmcIsSuccessful(true)
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(false)
+				waitForFtdDeleteStateMachineEndedSuccessful(false)
+				deleteFtdIsSuccessful(true)
 			},
 			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
 				assert.NotNil(t, err)
@@ -113,16 +120,94 @@ func TestDeleteCloudFtd(t *testing.T) {
 			},
 		},
 		{
-			testName: "error when failed to wait for FTD delete state machine starts, and waited before error",
+			testName: "error when failed to read FMC domain info",
 			input:    cloudftd.NewDeleteInput(ftdUid),
 			setupFunc: func() {
 				readFmcIsSuccessful(true)
 				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(false)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
 				triggerFtdDeleteOnFmcIsSuccessful(true)
-				waitForFtdDeleteStateMachineTriggeredReturnedNotFound()
-				waitForFtdDeleteStateMachineTriggeredReturnedNotFound()
-				waitForFtdDeleteStateMachineTriggeredReturnedNotFound()
-				waitForFtdDeleteStateMachineTriggeredIsSuccessful(false)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
+			},
+			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
+				assert.NotNil(t, err)
+				assert.Nil(t, output)
+			},
+		},
+		{
+			testName: "error when failed to read FTD",
+			input:    cloudftd.NewDeleteInput(ftdUid),
+			setupFunc: func() {
+				readFmcIsSuccessful(true)
+				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(false)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
+				triggerFtdDeleteOnFmcIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
+			},
+			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
+				assert.NotNil(t, err)
+				assert.Nil(t, output)
+			},
+		},
+		{
+			testName: "error when failed to read FMC device records",
+			input:    cloudftd.NewDeleteInput(ftdUid),
+			setupFunc: func() {
+				readFmcIsSuccessful(true)
+				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(false)
+				readFtdDeviceRecordIsSuccessful(true)
+				triggerFtdDeleteOnFmcIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
+			},
+			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
+				assert.NotNil(t, err)
+				assert.Nil(t, output)
+			},
+		},
+		{
+			testName: "error when failed to read FTD device record in FMC",
+			input:    cloudftd.NewDeleteInput(ftdUid),
+			setupFunc: func() {
+				readFmcIsSuccessful(true)
+				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(false)
+				triggerFtdDeleteOnFmcIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(true)
+			},
+			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
+				assert.NotNil(t, err)
+				assert.Nil(t, output)
+			},
+		},
+		{
+			testName: "error when failed to delete FTD in CDO",
+			input:    cloudftd.NewDeleteInput(ftdUid),
+			setupFunc: func() {
+				readFmcIsSuccessful(true)
+				readFmcSpecificIsSuccessful(true)
+				readFmcDomainInfoIsSuccessful(true)
+				readFtdIsSuccessful(true)
+				readFmcDeviceRecordsIsSuccessful(true)
+				readFtdDeviceRecordIsSuccessful(true)
+				triggerFtdDeleteOnFmcIsSuccessful(true)
+				waitForFtdDeleteStateMachineEndedSuccessful(true)
+				deleteFtdIsSuccessful(false)
 			},
 			assertFunc: func(output *cloudftd.DeleteOutput, err error, t *testing.T) {
 				assert.NotNil(t, err)
@@ -148,7 +233,87 @@ func TestDeleteCloudFtd(t *testing.T) {
 	}
 }
 
-func waitForFtdDeleteStateMachineTriggeredIsSuccessful(success bool) {
+func deleteFtdIsSuccessful(success bool) {
+	if success {
+		httpmock.RegisterResponder(
+			http.MethodDelete,
+			url.DeleteDevice(baseUrl, ftdUid),
+			httpmock.NewJsonResponderOrPanic(200, validDeleteOutput),
+		)
+	} else {
+		httpmock.RegisterResponder(
+			http.MethodDelete,
+			url.DeleteDevice(baseUrl, ftdUid),
+			httpmock.NewJsonResponderOrPanic(500, "intentional error"),
+		)
+	}
+}
+
+func readFtdDeviceRecordIsSuccessful(success bool) {
+	if success {
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			url.ReadFmcDeviceRecord(baseUrl, fmcDomainUid, ftdDeviceRecordId),
+			httpmock.NewJsonResponderOrPanic(200, validReadFtdDeviceRecordOutput),
+		)
+	} else {
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			url.ReadFmcDeviceRecord(baseUrl, fmcDomainUid, ftdDeviceRecordId),
+			httpmock.NewJsonResponderOrPanic(500, "intentional error"),
+		)
+	}
+}
+
+func readFmcDeviceRecordsIsSuccessful(success bool) {
+	if success {
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			url.ReadFmcAllDeviceRecords(baseUrl, fmcDomainUid),
+			httpmock.NewJsonResponderOrPanic(200, validReadDeviceRecordsOutput),
+		)
+	} else {
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			url.ReadFmcAllDeviceRecords(baseUrl, fmcDomainUid),
+			httpmock.NewJsonResponderOrPanic(500, "intentional error"),
+		)
+	}
+}
+
+func readFtdIsSuccessful(success bool) {
+	if success {
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			url.ReadDevice(baseUrl, ftdUid),
+			httpmock.NewJsonResponderOrPanic(200, validReadFtdOutput),
+		)
+	} else {
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			url.ReadDevice(baseUrl, ftdUid),
+			httpmock.NewJsonResponderOrPanic(500, "intentional error"),
+		)
+	}
+}
+
+//func readFmcDomainInfoIsSuccessful(success bool) {
+//	if success {
+//		httpmock.RegisterResponder(
+//			http.MethodGet,
+//			url.ReadFmcDomainInfo(fmcHost),
+//			httpmock.NewJsonResponderOrPanic(200, validReadFmcDomainInfoOutput),
+//		)
+//	} else {
+//		httpmock.RegisterResponder(
+//			http.MethodGet,
+//			url.ReadFmcDomainInfo(fmcHost),
+//			httpmock.NewJsonResponderOrPanic(500, "intentional error"),
+//		)
+//	}
+//}
+
+func waitForFtdDeleteStateMachineEndedSuccessful(success bool) {
 	if success {
 		httpmock.RegisterResponder(
 			http.MethodGet,

--- a/client/device/cloudftd/fixture_test.go
+++ b/client/device/cloudftd/fixture_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/device/cloudftd"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/statemachine"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/cloudfmc/accesspolicies"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/cloudfmc/fmcconfig"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/cloudfmc/fmcdomain"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/device/tags"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/ftd/license"
@@ -58,6 +59,8 @@ const (
 	ftdSpecificType      = "unit-test-ftd-specific-type"
 	ftdSpecificState     = "unit-test-ftd-specific-state"
 	ftdSpecificNamespace = "unit-test-ftd-specific-namespace"
+
+	ftdDeviceRecordId = "unit-test-ftd-device-record-id"
 )
 
 var (
@@ -76,17 +79,17 @@ var (
 			Build(),
 	}
 
+	validFmcDomainItem = fmcdomain.NewItem(
+		fmcDomainItemUid,
+		fmcDomainItemName,
+		fmcDomainItemType,
+	)
+
 	validReadFmcDomainInfoOutput = fmcdomain.NewInfoBuilder().
 					Links(fmcdomain.NewLinks(fmcLink)).
 					Paging(fmcdomain.NewPaging(fmcDomainCount, fmcDomainOffset, fmcDomainLimit, fmcDomainPages)).
-					Items([]fmcdomain.Item{
-			fmcdomain.NewItem(
-				fmcDomainItemUid,
-				fmcDomainItemName,
-				fmcDomainItemType,
-			),
-		}).
-		Build()
+					Items([]fmcdomain.Item{validFmcDomainItem}).
+					Build()
 
 	validReadAccessPoliciesOutput = accesspolicies.Builder().
 					Links(accesspolicies.NewLinks(fmcLink)).
@@ -104,16 +107,34 @@ var (
 		)}).
 		Build()
 
+	validFtdMetadata = cloudftd.NewMetadataBuilder().
+				LicenseCaps(ftdLicenseCaps).
+				AccessPolicyName(ftdAccessPolicyName).
+				PerformanceTier(&ftdPerformanceTier).
+				CloudManagerDomain(ftdCloudManagerDomain).
+				Build()
+
 	validCreateFtdOutput = cloudftd.NewCreateOutputBuilder().
 				Name(ftdName).
 				Uid(ftdUid).
-				Metadata(cloudftd.NewMetadataBuilder().
-					LicenseCaps(ftdLicenseCaps).
-					AccessPolicyName(ftdAccessPolicyName).
-					PerformanceTier(&ftdPerformanceTier).
-					CloudManagerDomain(ftdCloudManagerDomain).
-					Build()).
+				Metadata(validFtdMetadata).
 				Build()
+
+	validReadDeviceRecordsOutput = fmcconfig.NewAllDeviceRecordsBuilder().
+					Items([]fmcconfig.Item{fmcconfig.NewItem(ftdDeviceRecordId, ftdName, fmcDomainItemType, fmcconfig.NewLinks(""))}).
+					Build()
+
+	validReadFtdOutput = cloudftd.NewReadOutputBuilder().
+				Name(ftdName).
+				Uid(ftdUid).
+				Metadata(validFtdMetadata).
+				Build()
+
+	validReadFtdDeviceRecordOutput = fmcconfig.DeviceRecord{
+		Id:               ftdDeviceRecordId,
+		Model:            "Firepower Threat Defense",
+		DeploymentStatus: "DEPLOYED",
+	}
 
 	validUpdateSpecificFtdOutput = cloudftd.NewUpdateSpecificFtdOutputBuilder().
 					SpecificUid(ftdSpecificUid).
@@ -155,6 +176,7 @@ var (
 
 	validReadStateMachineOutput = statemachine.NewReadInstanceByDeviceUidOutputBuilder().
 					StateMachineIdentifier("fmceDeleteFtdcStateMachine").
+					StateMachineInstanceCondition(state.DONE).
 					Build()
 
 	validDeleteOutput = cloudftd.DeleteOutput{}

--- a/client/device/cloudftd/read_by_name.go
+++ b/client/device/cloudftd/read_by_name.go
@@ -30,7 +30,7 @@ func ReadByName(ctx context.Context, client http.Client, readInp ReadByNameInput
 	}
 
 	if len(readOutp) == 0 {
-		return nil, fmt.Errorf("cloudftd with name: \"%s\" not found", readInp.Name)
+		return nil, fmt.Errorf("%w: cloudftd with name \"%s\" not found", http.NotFoundError, readInp.Name)
 	}
 
 	if len(readOutp) > 1 {

--- a/client/device/read_by_nameandtype.go
+++ b/client/device/read_by_nameandtype.go
@@ -34,7 +34,7 @@ func ReadByNameAndType(ctx context.Context, client http.Client, readInp ReadByNa
 	}
 
 	if len(arrayOutp) == 0 {
-		return nil, fmt.Errorf("no Device by name %s and device type %s found", readInp.Name, readInp.DeviceType)
+		return nil, fmt.Errorf("%w: no Device by name %s and device type %s found", http.NotFoundError, readInp.Name, readInp.DeviceType)
 	}
 
 	if len(arrayOutp) > 1 {

--- a/client/internal/statemachine/error.go
+++ b/client/internal/statemachine/error.go
@@ -3,6 +3,7 @@ package statemachine
 import (
 	"fmt"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/cdo"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
 	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/model/statemachine"
 )
 
@@ -19,7 +20,7 @@ func (err errorType) Error() string {
 // Error facilitates `errors.Is(err, statemachine.Error)`.
 var Error ErrorType = errorType{}
 
-var NotFoundError = fmt.Errorf("%w: state machine not found", Error)
+var NotFoundError = fmt.Errorf("%w: %w: state machine not found", http.NotFoundError, Error)
 
 var MoreThanOneRunningError = fmt.Errorf("%w: multiple running instances found, this is not expected, please report this issue at: %s", Error, cdo.TerraformProviderCDOIssuesUrl)
 

--- a/provider/internal/util/404error.go
+++ b/provider/internal/util/404error.go
@@ -1,7 +1,10 @@
 package util
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 func Is404Error(err error) bool {
-	return strings.Contains(err.Error(), "code=404")
+	return strings.Contains(err.Error(), http.StatusText(http.StatusNotFound))
 }


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-73399

### Description
See the jira link above for an explanation of the bug. Basically what we need to do is to send the delete FTD object by UID after waiting for the FTD deletion state machine to finish (started by state=PENDING_DELETE_FTDC), instead of just waiting for it to start.

### Things done in this PR
- Waited for the current deployment in the FTD to finish, otherwise the FTD deletion state machine will fail. To do this we need to:
	- Read the FTD device record in FMC, to do this we need to:
		- loop through all device records of the FMC because I did not find any parameter that allowed me to filter by device type / device name. To do this we need to:
			- Read FMC domain info for its domain uid.
			- Read FTD for its name to compare with the name in the FMC device records.
- Also fixed a bug where sometimes we raise an not found error in terraform during create (we should just tell terraform to re-create this resource). We were intercepting this not found error by checking for string in the error contains `code=404`, which does not handle the case where where we raise not found error for empty array response. Instead we now explicitly checking 404 status text.
			
