### PR TITLE
fix(LH-73551): FTD License Inconsistency

### DIFF
--- a/client/model/ftd/license/license.go
+++ b/client/model/ftd/license/license.go
@@ -144,6 +144,12 @@ func LicensesToFmcLicenses(licenses []Type) []Type {
 	})
 }
 
+func LicensesToCdoLicenses(licenses []Type) []Type {
+	return sliceutil.Map(licenses, func(l Type) Type {
+		return replaceFmcTermWithCdoTerm(l)
+	})
+}
+
 func StringToCdoStrings(licenses string) ([]string, error) {
 	licenseTypes, err := StringToCdoLicenses(licenses)
 	if err != nil {

--- a/provider/examples/resources/ftd/terraform.tfvars
+++ b/provider/examples/resources/ftd/terraform.tfvars
@@ -1,1 +1,2 @@
-ftd_name = "weilluo"
+ftd_name = "test-ftd"
+create_igw = true

--- a/provider/internal/device/ftd/operation.go
+++ b/provider/internal/device/ftd/operation.go
@@ -161,10 +161,14 @@ func Update(ctx context.Context, resource *Resource, planData *ResourceModel, st
 		return err
 	}
 
+	licensesStrings, err := license.StringToCdoStrings(res.Metadata.LicenseCaps)
+	if err != nil {
+		return err
+	}
 	// map return struct to model
 	stateData.Name = types.StringValue(res.Name)
 	stateData.Labels = planData.Labels
-	stateData.Licenses = planData.Licenses
+	stateData.Licenses = util.GoStringSliceToTFStringSet(licensesStrings)
 
 	return nil
 }

--- a/provider/internal/device/ftd/resource.go
+++ b/provider/internal/device/ftd/resource.go
@@ -273,6 +273,11 @@ func (r *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValida
 }
 
 func (r *Resource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		// destroying, ignore
+		return
+	}
+
 	var planData ResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
 	if resp.Diagnostics.HasError() {

--- a/provider/internal/device/ftd/resource.go
+++ b/provider/internal/device/ftd/resource.go
@@ -26,6 +26,7 @@ import (
 var _ resource.Resource = &Resource{}
 var _ resource.ResourceWithImportState = &Resource{}
 var _ resource.ResourceWithConfigValidators = &Resource{}
+var _ resource.ResourceWithModifyPlan = &Resource{}
 
 func NewResource() resource.Resource {
 	return &Resource{}
@@ -269,4 +270,25 @@ func (r *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValida
 	return []resource.ConfigValidator{
 		performanceTierConfigValidator{},
 	}
+}
+
+func (r *Resource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	var planData ResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// convert input (possibly FMC licenses) to CDO licenses
+	licenses, err := util.TFStringSetToLicenses(ctx, planData.Licenses)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to convert licenses", err.Error())
+		return
+	}
+	licenses = license.LicensesToCdoLicenses(licenses)
+	licenseStrings := license.LicensesToStrings(licenses)
+
+	planData.Licenses = util.GoStringSliceToTFStringSet(licenseStrings)
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &planData)...)
 }


### PR DESCRIPTION
https://jira-eng-rtp3.cisco.com/jira/browse/LH-73551

### Description
To reproduce the bug:
1. create a FTD in CDO with FMC license. (i.e. `URL` instead of `URLFilter`, `ESSENTIALS` instead of `BASE`)
2. apply (success)
3. apply again (unexpected changes from CDO license to FMC license)

This is because I store the state as CDO license, but I forget to change the input from FMC license to CDO license. So during the first apply, the FMC license is changed to the CDO license is stored in the state, the next time the user apply, terraform finds the plan has the FMC license which is different from the state, it prompts the user for change. Although technically it does not make a difference because the license will be converted into CDO license later on, but we should be having a `ModifyPlan` function that tells terraform they are the same thing so that user will not be prompted for changes. Note that the user should not be providing us with a FMC license, but we have to handle the FMC license case as well because our backend can randomly give us FTD/FMC license.