### PR TITLE
fix(lh-87215): allow deletion of MSP-managed tenants

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -284,6 +284,10 @@ func (c *Client) ReadMspManagedTenantByUid(ctx context.Context, readByUidInput t
 	return tenants.ReadByUid(ctx, c.client, readByUidInput)
 }
 
+func (c *Client) DeleteMspManagedTenantByUid(ctx context.Context, deleteByUidInput tenants.DeleteByUidInput) (interface{}, error) {
+	return tenants.DeleteByUid(ctx, c.client, deleteByUidInput)
+}
+
 func (c *Client) FindMspManagedTenantByName(ctx context.Context, readByNameInput tenants.ReadByNameInput) (*tenants.MspTenantsOutput, error) {
 	return tenants.ReadByName(ctx, c.client, readByNameInput)
 }

--- a/client/internal/url/url.go
+++ b/client/internal/url/url.go
@@ -210,7 +210,7 @@ func CreateMspManagedTenant(baseUrl string) string {
 	return fmt.Sprintf("%s/api/rest/v1/msp/tenants/create", baseUrl)
 }
 
-func ReadMspManagedTenantByUid(baseUrl string, tenantUid string) string {
+func MspManagedTenantByUid(baseUrl string, tenantUid string) string {
 	return fmt.Sprintf("%s/api/rest/v1/msp/tenants/%s", baseUrl, tenantUid)
 }
 

--- a/client/msp/tenants/delete.go
+++ b/client/msp/tenants/delete.go
@@ -1,0 +1,17 @@
+package tenants
+
+import (
+	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/url"
+)
+
+func DeleteByUid(ctx context.Context, client http.Client, deleteInp DeleteByUidInput) (interface{}, error) {
+	client.Logger.Println("Removing tenant by UID from the MSP portal " + deleteInp.Uid)
+	deleteUrl := url.MspManagedTenantByUid(client.BaseUrl(), deleteInp.Uid)
+	if err := client.NewDelete(ctx, deleteUrl).Send(&DeleteOutput{}); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/client/msp/tenants/delete_test.go
+++ b/client/msp/tenants/delete_test.go
@@ -1,0 +1,50 @@
+package tenants_test
+
+import (
+	"context"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/internal/http"
+	"github.com/CiscoDevnet/terraform-provider-cdo/go-client/msp/tenants"
+	"github.com/google/uuid"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	netHttp "net/http"
+	"testing"
+	"time"
+)
+
+func TestDelete(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	t.Run("successfully delete tenant", func(t *testing.T) {
+		httpmock.Reset()
+		var tenantUid = uuid.New().String()
+		var deleteInput = tenants.DeleteByUidInput{
+			Uid: tenantUid,
+		}
+		httpmock.RegisterResponder(
+			netHttp.MethodDelete,
+			"/api/rest/v1/msp/tenants/"+tenantUid,
+			httpmock.NewJsonResponderOrPanic(204, nil),
+		)
+		response, err := tenants.DeleteByUid(context.Background(), *http.MustNewWithConfig(baseUrl, "valid_token", 0, 0, time.Minute), deleteInput)
+		assert.Nil(t, response)
+		assert.Nil(t, err)
+	})
+
+	t.Run("send through error if deletion failed", func(t *testing.T) {
+		httpmock.Reset()
+		var tenantUid = uuid.New().String()
+		var deleteInput = tenants.DeleteByUidInput{
+			Uid: tenantUid,
+		}
+		httpmock.RegisterResponder(
+			netHttp.MethodDelete,
+			"/api/rest/v1/msp/tenants/"+tenantUid,
+			httpmock.NewJsonResponderOrPanic(500, "Not found"),
+		)
+		response, err := tenants.DeleteByUid(context.Background(), *http.MustNewWithConfig(baseUrl, "valid_token", 0, 0, time.Minute), deleteInput)
+		assert.Nil(t, response)
+		assert.NotNil(t, err)
+	})
+}

--- a/client/msp/tenants/models.go
+++ b/client/msp/tenants/models.go
@@ -26,3 +26,10 @@ type ReadByUidInput struct {
 type ReadByNameInput struct {
 	Name string `json:"name"`
 }
+
+type DeleteByUidInput struct {
+	Uid string `json:"uid"`
+}
+
+type DeleteOutput struct {
+}

--- a/client/msp/tenants/read.go
+++ b/client/msp/tenants/read.go
@@ -9,7 +9,7 @@ import (
 func ReadByUid(ctx context.Context, client http.Client, readInp ReadByUidInput) (*MspTenantOutput, error) {
 	client.Logger.Println("reading tenant by UID " + readInp.Uid)
 
-	readUrl := url.ReadMspManagedTenantByUid(client.BaseUrl(), readInp.Uid)
+	readUrl := url.MspManagedTenantByUid(client.BaseUrl(), readInp.Uid)
 	req := client.NewGet(ctx, readUrl)
 
 	var outp MspTenantOutput

--- a/client/msp/users/delete.go
+++ b/client/msp/users/delete.go
@@ -21,7 +21,7 @@ func Delete(ctx context.Context, client http.Client, deleteInp MspDeleteUsersInp
 		return nil, err
 	}
 
-	transaction, err = publicapi.WaitForTransactionToFinishWithDefaults(
+	_, err = publicapi.WaitForTransactionToFinishWithDefaults(
 		ctx,
 		client,
 		transaction,

--- a/docs/resources/msp_managed_tenant.md
+++ b/docs/resources/msp_managed_tenant.md
@@ -3,12 +3,12 @@
 page_title: "cdo_msp_managed_tenant Resource - cdo"
 subcategory: ""
 description: |-
-  Provides an MSP managed tenant resource. This allows MSP managed tenants to be created.
+  Provides an MSP managed tenant resource. This allows MSP managed tenants to be created. Note: deleting this resource removes the created tenant from the MSP portal by disassociating the tenant from the MSP portal, but the tenant will continue to exist. To completely delete a tenant, please contact Cisco TAC.
 ---
 
 # cdo_msp_managed_tenant (Resource)
 
-Provides an MSP managed tenant resource. This allows MSP managed tenants to be created.
+Provides an MSP managed tenant resource. This allows MSP managed tenants to be created. Note: deleting this resource removes the created tenant from the MSP portal by disassociating the tenant from the MSP portal, but the tenant will continue to exist. To completely delete a tenant, please contact Cisco TAC.
 
 
 


### PR DESCRIPTION

https://jira-eng-rtp3.cisco.com/jira/browse/LH-87215

### Description

This is a faux deletion, as described in the documentation. It removes the tenant from the MSP
portal, but doesn't actually delete it from the database.

